### PR TITLE
Updating SCTs in chapter 1.

### DIFF
--- a/chapter1.md
+++ b/chapter1.md
@@ -55,20 +55,18 @@ Remember that a user can only interact with an operating system through a progra
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:7c1481dbd3
 ## Where am I?
 
-The **filesystem**
-organizes data into files and directories (also called "folders").
-Every file or directory is identified by an **absolute path**
-that specifies how to get to it from the top (or **root**) of the filesystem.
-For example,
-`/home/repl` is the path to a directory called `repl` inside a directory called `home`,
-while `/home/repl/course.txt` identifies a file `course.txt` in that directory.
-`/` on its own identifies the root directory.
+The **filesystem** manages files and directories (or folders).
+Each is identified by an **absolute path**
+that shows how to reach it from the filesystem's **root directory**:
+`/home/repl` is the directory `repl` in the directory `home`,
+while `/home/repl/course.txt` is a file `course.txt` in that directory,
+and `/` on its own is the root directory.
 
 To find out where you are in the filesystem,
-type the command `pwd`
+run the command `pwd`
 (short for "**p**rint **w**orking **d**irectory").
-This tells you the absolute path of your **current working directory**,
-which is where the shell will run commands and look for files by default.
+This prints the absolute path of your **current working directory**,
+which is where the shell runs commands and looks for files by default.
 
 <hr>
 Run `pwd`.

--- a/chapter1.md
+++ b/chapter1.md
@@ -8,7 +8,7 @@ description : >-
 
 
 --- type:PureMultipleChoiceExercise lang:bash xp:50 key:badd717ea4
-## How does the shell compare to a graphical user interface?
+## How does the shell compare to a desktop interface?
 
 An operating system like Windows, Linux, or Mac OS is a special kind of program.
 It controls the computer's processor, hard drive, and network connection,
@@ -55,30 +55,23 @@ Remember that a user can only interact with an operating system through a progra
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:7c1481dbd3
 ## Where am I?
 
-The part of the operating system responsible for managing files and directories
-is called the **filesystem**.
-It organizes data into files,
-which hold information,
-and directories (also called "folders"),
-which hold files or other directories.
-
+The **filesystem**
+organizes data into files and directories (also called "folders").
 Every file or directory is identified by an **absolute path**
 that specifies how to get to it from the top (or **root**) of the filesystem.
 For example,
-the path `/home/repl` is the path to a directory called `repl` inside a directory called `home`,
-while `/home/repl/course.txt` identifies a file `course.txt` in that directory,
-and `/` on its own identifies the root directory.
+`/home/repl` is the path to a directory called `repl` inside a directory called `home`,
+while `/home/repl/course.txt` identifies a file `course.txt` in that directory.
+`/` on its own identifies the root directory.
 
 To find out where you are in the filesystem,
 type the command `pwd`
-(which stands for "print working directory").
+(short for "**p**rint **w**orking **d**irectory").
 This tells you the absolute path of your **current working directory**,
-which is where the shell will run commands and look for files
-unless and until you tell it to do so elsewhere.
-You can also use the command `whoami` to display your username.
+which is where the shell will run commands and look for files by default.
 
 <hr>
-Run `pwd` in the shell window to the right.
+Run `pwd`.
 Where are you right now?
 
 *** =instructions
@@ -104,26 +97,24 @@ Ex() >> test_mc(3, [err, err, correct])
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:f5b0499835
 ## How can I identify files and directories?
 
-`pwd` tells you where you are,
-but doesn't tell you what files and directories are there.
-To find out,
-you can type `ls` (which is short for "listing") and press the enter key.
+`pwd` tells you where you are.
+To find out what's there,
+type `ls` (which is short for "listing") and press the enter key.
 On its own,
 `ls` lists the contents of your current directory
 (the one displayed by `pwd`).
-If you add the names of one or more files,
-`ls` will list those files,
+If you add the names of some files,
+`ls` will list them,
 and if you add the names of directories,
 it will list their contents.
 For example,
-typing `ls /home/repl` will show you the contents of your starting directory
-(usually called your **home directory**),
-which it also shows you if you are in that directory and type `ls` on its own.
+`ls /home/repl` shows you what's in your starting directory
+(usually called your **home directory**).
 
 <hr>
-Use `ls` with an appropriate argument to get a listing of the files in the directory `/home/repl/seasonal`
+Use `ls` with an appropriate argument to list the files in the directory `/home/repl/seasonal`
 (which holds information on dental surgeries by date, broken down by season).
-Which of the following files is *not* in that directory?
+Which of these files is *not* in that directory?
 
 *** =instructions
 - `autumn.csv`
@@ -199,7 +190,8 @@ ls course.txt
 ```{python}
 from shellwhat_ext import test_cmdline
 Ex() >> test_cmdline([['ls', '', {'course.txt'}]],
-                     msg='Use `ls` followed by a relative path.')
+                     msg='Use `ls` followed by a relative path.') \
+     >> test_output_contains('course.txt', fixed=True, msg="'course.txt' should have been in your command's output")
 ```
 
 *** =type2: ConsoleExercise
@@ -229,8 +221,8 @@ ls seasonal/summer.csv
 *** =sct2
 ```{python}
 from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['ls', '', {'seasonal/summer.csv'}]],
-                     msg='Use `ls` followed by a relative path.')
+Ex() >> test_output_contains(r'seasonal/summer\.csv', fixed=False,
+                             msg="'seasonal/summer.csv' should have been in your command's output")
 ```
 
 *** =type3: ConsoleExercise
@@ -260,9 +252,11 @@ ls people
 *** =sct3
 ```{python}
 import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['ls', '', re.compile('^people/?')]],
-                     msg='Use `ls` followed by the relative path to the directory.')
+from shellwhat_ext import test_cmdline, rxc
+Ex() >> test_cmdline([['ls', '', rxc('^people/?')]],
+                     msg='Use `ls` followed by the relative path to the directory.') \
+     >> test_output_contains(r'agarwal\.txt', fixed=False,
+                             msg="The file 'agarwal.txt' should have been in your command's output")
 ```
 
 --- type:BulletConsoleExercise key:dbdaec5610
@@ -309,9 +303,10 @@ cd seasonal
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cd', '', re.compile(r'seasonal/?')]],
-                     msg='Use `cd` followed by a path.')
+from shellwhat_ext import test_cmdline, test_cwd, rxc
+Ex() >> test_cmdline([['cd', '', rxc(r'seasonal/?')]],
+                     msg='Use `cd` followed by a path.') \
+     >> test_cwd('/home/repl/seasonal', 'You are not in the expected directory')
 ```
 
 *** =type2: ConsoleExercise
@@ -338,9 +333,11 @@ pwd
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
+from shellwhat_ext import test_cmdline, test_cwd
 Ex() >> test_cmdline([['pwd']],
-                     msg='Remember: "print working directory".')
+                     msg='Remember: "print working directory".') \
+     >> test_cwd('/home/repl/seasonal',
+                 msg="You are not in the expected directory")
 ```
 
 *** =type3: ConsoleExercise
@@ -478,9 +475,12 @@ cp seasonal/summer.csv backup/summer.bck
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cp', '', [re.compile('(./)?seasonal/summer.csv'), re.compile('(./)?backup/summer.bck')]]],
-                     msg='Provide two paths to `cp`.')
+import os
+from shellwhat_ext import test_cmdline, test_condition, rxc
+Ex() >> test_cmdline([['cp', '', [rxc('(./)?seasonal/summer.csv'), rxc('(./)?backup/summer.bck')]]],
+                     msg='Provide two paths to `cp`.') \
+     >> test_condition('summer.bck' in os.listdir('/home/repl/backup'),
+                       msg="'summer.bck' doesn't appear to exist in the 'backup' directory")
 ```
 
 *** =type2: ConsoleExercise
@@ -511,10 +511,14 @@ cp seasonal/spring.csv seasonal/summer.csv backup
 *** =sct2
 ```{python}
 import re
-from shellwhat_ext import test_cmdline
+from shellwhat_ext import test_cmdline, test_condition
 msg = 'Provide two filenames and a directory name to `cp`.'
-Ex() >> test_or(test_cmdline([['cp', '', ['seasonal/spring.csv', 'seasonal/summer.csv', re.compile(r'backup/?')]]], msg=msg),
-                test_cmdline([['cp', '', ['seasonal/summer.csv', 'seasonal/spring.csv', re.compile(r'backup/?')]]], msg=msg))
+import os
+backup_files = os.listdir('/home/repl/backup')
+Ex() >> test_condition('spring.csv' in backup_files,
+                       msg="'spring.csv' doesn't appear to have been copied into the 'backup' directory") \
+     >> test_condition('summer.csv' in backup_files,
+                       msg="'summer.csv' doesn't appear to have been copied into the 'backup' directory")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:663a083a3c
@@ -547,11 +551,16 @@ mv seasonal/spring.csv seasonal/summer.csv backup
 
 *** =sct
 ```{python}
+import os
 import re
-from shellwhat_ext import test_cmdline
-msg = 'Use two filenames and a directory name as parameters.'
-Ex() >> test_or(test_cmdline([['mv', '', ['seasonal/spring.csv', 'seasonal/summer.csv', re.compile(r'backup/?')]]], msg=msg),
-                test_cmdline([['mv', '', ['seasonal/summer.csv', 'seasonal/spring.csv', re.compile(r'backup/?')]]], msg=msg))
+from shellwhat_ext import test_cmdline, test_condition
+seasonal_files = os.listdir('/home/repl/seasonal')
+backup_files = os.listdir('/home/repl/backup')
+Ex() >> test_student_typed(r'^\s*mv', fixed=False, msg='Use two filenames and a directory name as parameters.') \
+     >> test_condition('spring.csv' in backup_files, msg="Was expecting 'spring.csv' in the 'backup' directory") \
+     >> test_condition('summer.csv' in backup_files, msg="Was expecting 'summer.csv' in the 'backup' directory") \
+     >> test_condition('spring.csv' not in seasonal_files, msg="Wasn't expecting 'spring.csv' to still be in the 'seasonal' directory") \
+     >> test_condition('summer.csv' not in seasonal_files, msg="Wasn't expecting 'summer.csv' to still be in the 'seasonal' directory")
 ```
 
 --- type:BulletConsoleExercise key:001801a652
@@ -605,9 +614,11 @@ cd seasonal
 *** =sct1
 ```{python}
 import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cd', '', re.compile(r'seasonal/?')]],
-                     msg='Use `cd` to change directory.')
+from shellwhat_ext import test_cmdline, test_cwd, rxc
+Ex() >> test_cmdline([['cd', '', rxc(r'seasonal/?')]],
+                     msg='Use `cd` to change directory.') \
+     >> test_cwd('/home/repl/seasonal',
+                 msg="You are not in the expected directory")
 ```
 
 *** =type2: ConsoleExercise
@@ -634,9 +645,13 @@ mv winter.csv winter.csv.bck
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
+import os
+from shellwhat_ext import test_cmdline, test_condition
+contents = os.listdir('/home/repl/seasonal')
 Ex() >> test_cmdline([['mv', '', ['winter.csv', 'winter.csv.bck']]],
-                     msg='Use `mv` to rename a file.')
+                     msg='Use `mv` to rename a file.') \
+     >> test_condition('winter.csv.bck' in contents, "Was expecting 'winter.csv.bck' to be in the directory") \
+     >> test_condition('winter.csv' not in contents, "Was not expecting 'winter.csv' to still be in the directory")
 ```
 
 *** =type3: ConsoleExercise
@@ -721,9 +736,11 @@ cd seasonal
 *** =sct1
 ```{python}
 import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cd', '', re.compile(r'seasonal/?')]],
-                     msg='Use `cd` to change directory.')
+from shellwhat_ext import test_cmdline, test_cwd, rxc
+Ex() >> test_cmdline([['cd', '', rxc(r'seasonal/?')]],
+                     msg='Use `cd` to change directory.') \
+     >> test_cwd('/home/repl/seasonal',
+                 msg="You are not in the expected directory")
 ```
 
 *** =type2: ConsoleExercise
@@ -750,9 +767,12 @@ rm autumn.csv
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
+import os
+from shellwhat_ext import test_cmdline, test_condition
 Ex() >> test_cmdline([['rm', '', 'autumn.csv']],
-                     msg='Use `rm` to remove a single file.')
+                     msg='Use `rm` to remove a single file.') \
+     >> test_condition('autumn.csv' not in os.listdir('/home/repl/seasonal'),
+                       msg="Wasn't expecting 'autumn.csv' to still be in the 'seasonal' directory")
 ```
 
 *** =type3: ConsoleExercise
@@ -779,9 +799,12 @@ cd
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'\s*cd(\s+(\.\.|\~))?\s*',
+from shellwhat_ext import test_cwd
+Ex() >> test_student_typed(r'^\s*cd',
                            fixed=False,
-                           msg='Use `cd ..` to go up a level or `cd ~` to return home.')
+                           msg='Use `cd ..` to go up a level or `cd ~` to return home.') \
+     >> test_cwd('/home/repl',
+                 msg="You don't appear to be in your home directory")
 ```
 
 *** =type4: ConsoleExercise
@@ -808,9 +831,12 @@ rm seasonal/summer.csv
 
 *** =sct4
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['rm', '', re.compile('(./)?seasonal/summer.csv')]],
-                     msg='`rm` also works with paths! So try removing `summer.csv` without getting inside `seasonal`.')
+import os
+from shellwhat_ext import test_cmdline, test_condition, rxc
+Ex() >> test_cmdline([['rm', '', rxc('(./)?seasonal/summer.csv')]],
+                     msg='`rm` also works with paths! So try removing `summer.csv` without getting inside `seasonal`.') \
+     >> test_condition('summer.csv' not in os.listdir('/home/repl/seasonal'),
+                       msg="'summer.csv' should not still be in the 'seasonal' directory")
 ```
 
 --- type:BulletConsoleExercise key:63e8fbd0c2
@@ -863,9 +889,12 @@ rm people/agarwal.txt
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
+import os
+from shellwhat_ext import test_cmdline, test_condition
 Ex() >> test_cmdline([['rm', '', 'people/agarwal.txt']],
-                     msg='Remove the file inside `people`.')
+                     msg='Remove the file inside `people`.') \
+     >> test_condition('agarwal.txt' not in os.listdir('/home/repl/people'),
+                       msg="'agarwal.txt' should not still be in '/home/repl/people'")
 ```
 
 *** =type2: ConsoleExercise
@@ -893,10 +922,13 @@ rmdir people
 
 *** =sct2
 ```{python}
+import os
 import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['rmdir', '', re.compile('people/?')]],
-                     msg='Remove the directory `people`.')
+from shellwhat_ext import test_cmdline, test_condition, rxc
+Ex() >> test_cmdline([['rmdir', '', rxc('people/?')]],
+                     msg='Remove the directory `people`.') \
+     >> test_condition('people' not in os.listdir('/home/repl'),
+                       msg="The 'people' directory should no longer be in your home directory")
 ```
 
 *** =type3: ConsoleExercise
@@ -926,9 +958,12 @@ mkdir yearly
 
 *** =sct3
 ```{python}
-from shellwhat_ext import test_cmdline
+import os
+from shellwhat_ext import test_cmdline, test_condition
 Ex() >> test_cmdline([['mkdir', '', 'yearly']],
-                     msg='Make the upper directory.')
+                     msg='Make the upper directory.') \
+     >> test_condition('yearly' in os.listdir('/home/repl'),
+                       msg="Cannot find a 'yearly' directory in your home directory")
 ```
 
 *** =type4: ConsoleExercise
@@ -957,9 +992,12 @@ mkdir yearly/2017
 
 *** =sct4
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['mkdir', '', 'yearly/2017']],
-                     msg='Make the lower directory using a relative path.')
+import os
+from shellwhat_ext import test_cmdline, test_condition, rxc
+Ex() >> test_cmdline([['mkdir', '', rxc('yearly/2017')]],
+                     msg='Make the lower directory using a relative path.') \
+     >> test_condition('2017' in os.listdir('/home/repl/yearly'),
+                       msg="Cannot find a '2017' directory in '/home/repl/yearly'")
 ```
 
 --- type:BulletConsoleExercise key:b1990e9a42
@@ -1001,9 +1039,11 @@ cd /tmp
 *** =sct1
 ```{python}
 import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cd', '', re.compile(r'^/tmp/?')]],
-                     msg='Change your directory to `/tmp`.')
+from shellwhat_ext import test_cmdline, test_cwd, rxc
+Ex() >> test_cmdline([['cd', '', rxc(r'^/tmp/?')]],
+                     msg='Change your directory to `/tmp`.') \
+     >> test_cwd('/tmp',
+                 msg="Expected to be in '/tmp'")
 ```
 
 
@@ -1057,9 +1097,12 @@ mkdir scratch
 
 *** =sct3
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['mkdir', '', re.compile('(./)?scratch')]],
-                     msg='Use `mkdir` followed by the relative path of the directory you want to create.')
+import os
+from shellwhat_ext import test_cmdline, test_condition, rxc
+Ex() >> test_cmdline([['mkdir', '', rxc('(./)?scratch')]],
+                     msg='Use `mkdir` followed by the relative path of the directory you want to create.') \
+     >> test_condition('scratch' in os.listdir('/tmp'),
+                       msg="Cannot find a 'scratch' directory under '/tmp'")
 ```
 
 *** =type4: ConsoleExercise
@@ -1068,10 +1111,10 @@ Ex() >> test_cmdline([['mkdir', '', re.compile('(./)?scratch')]],
 *** =xp4: 30
 
 *** =instructions4
-Move `/home/repl/people/agarwal.txt` into `/tmp`
+Move `/home/repl/people/agarwal.txt` into `/tmp/scratch`
 using the `~` shortcut for your home directory
 and a relative path for the second
-rather than the absolute path `/home/repl/tmp`.
+rather than the absolute path.
 
 *** =sample_code4
 ```{shell}
@@ -1079,13 +1122,16 @@ rather than the absolute path `/home/repl/tmp`.
 
 *** =solution4
 ```{shell}
-mv ~/people/agarwal.txt .
+mv ~/people/agarwal.txt scratch
 ```
 
 *** =sct4
 ```{python}
+import os
 import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['mv', '', ['~/people/agarwal.txt', re.compile(r'^./?')]]],
-                     msg='Use `~/people/agarwal.txt` for the first parameter and `.` for the second.')
+from shellwhat_ext import test_cmdline, test_condition, rxc
+Ex() >> test_cmdline([['mv', '', ['~/people/agarwal.txt', rxc(r'scratch')]]],
+                     msg='Use `~/people/agarwal.txt` for the first parameter and `scratch` for the second.') \
+     >> test_condition('agarwal.txt' in os.listdir('/tmp/scratch'),
+                       msg="Cannot find 'agarwal.txt' in '/tmp/scratch'")
 ```

--- a/chapter3.md
+++ b/chapter3.md
@@ -52,14 +52,18 @@ tail -n 5 seasonal/winter.csv > last.csv
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['tail', 'n:', 'seasonal/winter.csv', {'-n': '5'}]],
+import os
+from shellwhat_ext import test_cmdline, test_file_content_condition, rxc
+Ex() >> test_cmdline([['tail', 'n:', rxc(r'seasonal/winter.csv$'), {'-n': '5'}]],
                      redirect='last.csv',
-                     msg='Use `tail` (with the proper flag) and `>` together.')
+                     msg='Use `tail` (with the proper flag) and `>` together.') \
+     >> test_file_content_condition('/home/repl/last.csv',
+                                    lambda t: len(t.strip().split()) == 5,
+                                    'Expected to find 5 lines in last.csv')
 ```
 
 --- type:BulletConsoleExercise key:f47d337593
-## How can I use one command's output as the input to another command?
+## How can I use a command's output as an input?
 
 Suppose you want to get lines from the middle of a file.
 More specifically,
@@ -105,10 +109,13 @@ tail -n 2 seasonal/winter.csv > bottom.csv
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['tail', 'n:', 'seasonal/winter.csv', {'-n' : '2'}]],
+from shellwhat_ext import test_cmdline, test_file_content_condition, rxc
+Ex() >> test_cmdline([['tail', 'n:', rxc(r'seasonal/winter.csv$'), {'-n' : '2'}]],
                      redirect='bottom.csv',
-                     msg='Use `tail` and `>` together.')
+                     msg='Use `tail` and `>` together.') \
+     >> test_file_content_condition('/home/repl/bottom.csv',
+                                    lambda t: len(t.strip().split()) == 2,
+                                    'Expected to find 2 lines in bottom.csv')
 ```
 
 *** =type2: ConsoleExercise
@@ -136,13 +143,15 @@ head -n 1 bottom.csv
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['head', 'n:', 'bottom.csv', {'-n' : '1'}]],
-                     msg='Use `head` on the temporary file.')
+from shellwhat_ext import test_cmdline, test_output_condition, rxc
+Ex() >> test_cmdline([['head', 'n:', rxc(r'bottom.csv$'), {'-n' : '1'}]],
+                     msg='Use `head` on the temporary file.') \
+     >> test_output_condition(lambda s: len(s.strip().split('\n')) == 1,
+                              msg="Expected a single line of output")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:b36aea9a1e
-## What's a better way to use one command's output as another command's input?
+## What's a better way to combine commands?
 
 Using redirection to combine commands has two drawbacks:
 
@@ -179,10 +188,12 @@ cut -d , -f 2 seasonal/summer.csv | grep -v Tooth
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cut', 'd:f:', 'seasonal/summer.csv', {'-d' : ',', '-f' : '2'}],
+from shellwhat_ext import test_cmdline, test_output_does_not_contain, rxc
+Ex() >> test_cmdline([['cut', 'd:f:', rxc(r'seasonal/summer.csv$'), {'-d' : ',', '-f' : '2'}],
                       ['grep', 'v', 'Tooth', {'-v': None}]],
-                     msg='Use `cut` and `grep`.')
+                     msg='Use `cut` and `grep`.') \
+     >> test_output_does_not_contain('Tooth',
+                                     msg='"Tooth" should not be in the output')
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:b8753881d6
@@ -215,11 +226,12 @@ cut -d , -f 2 seasonal/autumn.csv | grep -v Tooth | head -n 1
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cut', 'd:f:', 'seasonal/autumn.csv', {'-d' : ',', '-f' : '2'}],
+from shellwhat_ext import test_cmdline, rxc
+Ex() >> test_cmdline([['cut', 'd:f:', rxc(r'seasonal/autumn.csv$'), {'-d' : ',', '-f' : '2'}],
                       ['grep', 'v', 'Tooth', {'-v': None}],
                       ['head', 'n:', None, {'-n' : '1'}]],
-                     msg='Use `cut`, `grep`, and `head`.')
+                     msg='Use `cut`, `grep`, and `head`.') \
+     >> test_output_contains('canine', msg='The output should contain the word "canine"')
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:ae6a48d6aa
@@ -241,14 +253,15 @@ grep 2017-07 seasonal/spring.csv | wc -l
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['grep', '', [re.compile('((2017)?-07-?)|(((2017)?-)?07-)'), 'seasonal/spring.csv']],
+from shellwhat_ext import test_cmdline, rxc
+Ex() >> test_cmdline([['grep', '', [rxc('((2017)?-07-?)|(((2017)?-)?07-)'), rxc(r'seasonal/spring.csv$')]],
                       ['wc', 'l']],
-                     msg='Use `grep` and `wc`.')
+                     msg='Use `grep` and `wc`.') \
+     >> test_output_contains('3', msg="That doesn't appear to be the right number of lines.")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:602d47e70c
-## How can I specify many files with a single command?
+## How can I specify many files at once?
 
 Most shell commands will work on multiple files if you give them multiple filenames.
 For example,
@@ -295,7 +308,11 @@ head -n 3 seasonal/s* # ...or seasonal/s*.csv
 from shellwhat_ext import test_cmdline
 Ex() >> test_student_typed(r'\s*head\s+-n\s+3\s+s.+\s*',
                            fixed=False,
-                           msg='Remember that "spring" and "summer" both start with "s".')
+                           msg='Remember that "spring" and "summer" both start with "s".') \
+     >> test_output_contains('seasonal/spring.csv',
+                             msg="The name of the spring data file should have been in the output") \
+     >> test_output_contains('seasonal/summer.csv',
+                             msg="The name of the summer data file should have been in the output")
 ```
 
 --- type:PureMultipleChoiceExercise lang:bash xp:50 key:f8feeacd8c
@@ -354,11 +371,14 @@ cut -d , -f 2 seasonal/winter.csv | grep -v Tooth | sort -r
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cut', 'd:f:', 'seasonal/winter.csv', {'-d': ',', '-f' : '2'}],
+from shellwhat_ext import test_cmdline, test_output_does_not_contain, test_output_condition
+Ex() >> test_cmdline([['cut', 'd:f:', rxc(r'seasonal/winter.csv$'), {'-d': ',', '-f' : '2'}],
                       ['grep', 'v', 'Tooth', {'-v': None}],
                       ['sort', 'r']],
-                     msg='Use `cut` to get the column, `grep` to get rid of the header, and `sort -r` to sort.')
+                     msg='Use `cut` to get the column, `grep` to get rid of the header, and `sort -r` to sort.') \
+     >> test_output_does_not_contain('Tooth', msg='The word "Tooth" should not be in the output') \
+     >> test_output_condition(lambda s: len(s.strip().split('\n')) == 25,
+                              msg="The output doesn't have the expected number of lines")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:ed77aed337
@@ -406,7 +426,7 @@ it only has to keep the most recent unique line in memory.
 
 Write a pipeline to:
 
-- get the second column from all of the data files in `seasonal`,
+- get the second column from `seasonal/winter.csv`,
 - remove the word "Tooth" from the output so that only tooth names are displayed,
 - sort the output so that all occurrences of a particular tooth name are adjacent; and
 - display each tooth name once along with a count of how often it occurs.
@@ -415,21 +435,23 @@ Use `uniq -c` to display unique lines with a count of how often each occurs.
 
 *** =solution
 ```{shell}
-cut -d , -f 2 seasonal/*.csv | grep -v Tooth | sort | uniq -c
+cut -d , -f 2 seasonal/winter.csv | grep -v Tooth | sort | uniq -c
 ```
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cut', 'd:f:', '+', {'-d': ',', '-f' : '2'}],
+from shellwhat_ext import test_cmdline, test_output_condition, rxc
+Ex() >> test_cmdline([['cut', 'd:f:', rxc(r'seasonal/winter.csv$'), {'-d': ',', '-f' : '2'}],
                       ['grep', 'v', 'Tooth', {'-v': None}],
                       ['sort', 'r'],
                       ['uniq', 'c']],
-                     msg='Use `cut`, `grep -v`, `sort`, and `uniq -c`.')
+                     msg='Use `cut`, `grep -v`, `sort`, and `uniq -c`.') \
+     >> test_output_condition(lambda s: len(s.strip().split('\n')) == 5,
+                              msg="Expected to find 5 different kinds of teeth")
 ```
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:4115aa25b2
-## Pipes and Redirection
+## How can I save the output of a pipe?
 
 The shell lets us redirect the output of a sequence of piped commands:
 
@@ -444,9 +466,9 @@ if we try to use it in the middle, like this:
 cut -d , -f 2 seasonal/*.csv > teeth-only.txt | grep -v Tooth
 ```
 
-then since all of the output from `cut` is written to `teeth-only.txt`,
-there is nothing left for `grep`,
-so it waits forever for some input.
+then all of the output from `cut` is written to `teeth-only.txt`,
+so there is nothing left for `grep`
+and it waits forever for some input.
 
 <hr>
 
@@ -493,20 +515,21 @@ note that the 'c' can be lower-case.
 Run the command:
 
 ```{shell}
-head -n 1 seasonal/winter.csv > winter.txt | grep -v Tooth
+head
 ```
 
+with no arguments (so that it waits for input that will never come)
 and then stop it by typing Ctrl-C.
 
 *** =solution
 ```{bash}
 # Use 'echo' rather than actually running the command to prevent automated tests hanging up: 
-echo 'head -n 1 seasonal/winter.csv > winter.txt | grep -v Tooth'
+echo 'head'
 ```
 
 *** =sct
 ```{python}
-Ex() >> test_student_typed(r'\s*head\s+-n\s+1\s+seasonal/winter.csv\s*>\s*winter.txt\s*|\s*grep\s+-v\s+Tooth\s*',
+Ex() >> test_student_typed(r'\s*head\s*',
                            fixed=False,
                            msg="Use the control key and 'c' at the same time to stop the script.")
 ```
@@ -546,9 +569,11 @@ wc -l seasonal/*.csv
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['wc', 'l', '+']],
-                     msg='Use `wc -l` and `seasonal/*.csv`.')
+from shellwhat_ext import test_cmdline, test_output_condition, rxc
+Ex() >> test_cmdline([['wc', 'l', rxc(r'seasonal/\*.*?$')]],
+                     msg='Use `wc -l` and `seasonal/*.csv`.') \
+     >> test_output_condition(lambda s: len(s.strip().split('\n')) == 5,
+                              msg="There should be one line of output for each file, plus another for the total")
 ```
 
 *** =type2: ConsoleExercise
@@ -558,7 +583,7 @@ Ex() >> test_cmdline([['wc', 'l', '+']],
 
 *** =instructions2
 
-Add another command to the previous one using a pipe to remove the line reporting the total number of lines.
+Add another command to the previous one using a pipe to remove the line containing the word "total".
 
 *** =hint3
 
@@ -575,10 +600,12 @@ wc -l seasonal/*.csv | grep -v total
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
+from shellwhat_ext import test_cmdline, test_output_condition
 Ex() >> test_cmdline([['wc', 'l', '+'],
                       ['grep' ,'v', 'total']],
-                     msg='Use `grep -v total` as the second stage of the pipe.')
+                     msg='Use `grep -v total` as the second stage of the pipe.') \
+     >> test_output_condition(lambda s: len(s.strip().split('\n')) == 4,
+                              msg="There should be exactly one line of output for each file")
 ```
 
 *** =type3: ConsoleExercise
@@ -605,10 +632,14 @@ wc -l seasonal/*.csv | grep -v total | sort -n | head -n 1
 
 *** =sct3
 ```{python}
-from shellwhat_ext import test_cmdline
+from shellwhat_ext import test_cmdline, test_output_condition
 Ex() >> test_cmdline([['wc', 'l', '+'],
                       ['grep', 'v', 'total', {'-v': None}],
                       ['sort', 'n'],
                       ['head', 'n:', None, {'-n' : '1'}]],
-                     msg='Use `sort -n` and `head -n 1`.')
+                     msg='Use `sort -n` and `head -n 1`.') \
+     >> test_output_condition(lambda s: len(s.strip().split('\n')) == 1,
+                              msg="There should only be one line of output") \
+     >> test_output_contains('autumn.csv',
+                             msg="The file 'autumn.csv' is the shortest.")
 ```

--- a/requirements.sh
+++ b/requirements.sh
@@ -7,7 +7,9 @@ FILESYS=filesys.zip
 SOLUTIONS=solutions.zip
 PYTHON=python3
 PIP=pip3
-SHELLWHAT_EXT=git+https://github.com/datacamp/shellwhat_ext.git@v0.2.0
+
+# SHELLWHAT_EXT=git+https://github.com/datacamp/shellwhat_ext.git@v0.2.0
+SHELLWHAT_EXT=git+https://github.com/datacamp/shellwhat_ext.git@adding-condition-and-cwd
 
 # Report start.
 echo ''


### PR DESCRIPTION
@filipsch @sumedh10 please let me know if these kinds of changes are in the right direction to address https://github.com/datacamp/shellwhat/issues/38 - if so, I'll make similar updates to chapters 2-5.

1. Installing development version of `shellwhat_ext` that includes new utility functions.
2. Using those functions to test command results as well as what was typed.

This gets `shellwhat_ext` off a branch in that project's GitHub repo for now - `requirements.sh` should be updated to load a tagged version once https://github.com/datacamp/shellwhat_ext/pull/4 has been merged.

Reminder: use an explicit continuation character in:

```
Ex() >> first() \
     >> second()
```