### PR TITLE
Rewrite all SCTs according to new version of shellwhat

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -1,5 +1,3 @@
----
----
 # Citation
 
 Please cite this lesson as:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,3 @@
----
----
 # Contributing
 
 [DataCamp](https://www.datacamp.com/) welcomes bug reports, feature requests, and fixes. By contributing to this lesson, you agree that we may redistribute your work under [our license](LICENSE.md). In exchange, we will address your issues and/or assess your proposed changes as promptly as we can.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
----
----
 # Introduction to the Unix Shell for Data Science
 
-Teach: https://www.datacamp.com/teach/repositories/1395/branches/master
+Teach Admin: https://www.datacamp.com/teach/repositories/1395/branches/master
 
 ## Description
 
@@ -24,17 +22,3 @@ The Unix command line has survived and thrived for almost fifty years because it
 ## Prerequisites
 
 - None
-
-###  DataCamp Referral Program For B2B Customers
-
-:moneybag: :dollar:
-
-DataCamp is offering a special promotion where instructors can earn a referral fee for introducing DataCamp to new prospects.
-
-* You receive a 15% revenue share on the initial contract we sign with your referral (For example if you refer a financial service company that buys $30,000 worth of DataCamp subscriptions, we would pay you $4,500)
-* **Referrals are very easy to make and all you need to do is fill out [this referral form](https://docs.google.com/forms/d/e/1FAIpQLSeb9tGdH3akd2VA1uQpdftc218K_tEKhIUxAogYZoiH7zdPbg/viewform)**
-* This referral opportunity is in addition to the royalty payments you already receive
-* The primary target is businesses but we also sell to government agencies and graduate programs at universities
-
-More info: robert@datacamp.com
-

--- a/chapter1.md
+++ b/chapter1.md
@@ -8,7 +8,7 @@ description : >-
 
 
 --- type:PureMultipleChoiceExercise lang:bash xp:50 key:badd717ea4
-## How does the shell compare to a graphical user interface?
+## How does the shell compare to a desktop interface?
 
 An operating system like Windows, Linux, or Mac OS is a special kind of program.
 It controls the computer's processor, hard drive, and network connection,
@@ -46,7 +46,7 @@ What is the relationship between the graphical file explorer that most people us
 *** =hint
 Remember that a user can only interact with an operating system through a program.
 
-*** =feedbacks
+*** =feedback
 - Both allow you to view and edit files and run programs.
 - Graphical file explorers and the shell both call the same underlying operating system functions.
 - The shell and the file explorer are both programs that translate user commands (typed or clicked) into calls to the operating system.
@@ -55,30 +55,21 @@ Remember that a user can only interact with an operating system through a progra
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:7c1481dbd3
 ## Where am I?
 
-The part of the operating system responsible for managing files and directories
-is called the **filesystem**.
-It organizes data into files,
-which hold information,
-and directories (also called "folders"),
-which hold files or other directories.
-
-Every file or directory is identified by an **absolute path**
-that specifies how to get to it from the top (or **root**) of the filesystem.
-For example,
-the path `/home/repl` is the path to a directory called `repl` inside a directory called `home`,
-while `/home/repl/course.txt` identifies a file `course.txt` in that directory,
-and `/` on its own identifies the root directory.
+The **filesystem** manages files and directories (or folders).
+Each is identified by an **absolute path**
+that shows how to reach it from the filesystem's **root directory**:
+`/home/repl` is the directory `repl` in the directory `home`,
+while `/home/repl/course.txt` is a file `course.txt` in that directory,
+and `/` on its own is the root directory.
 
 To find out where you are in the filesystem,
-type the command `pwd`
-(which stands for "print working directory").
-This tells you the absolute path of your **current working directory**,
-which is where the shell will run commands and look for files
-unless and until you tell it to do so elsewhere.
-You can also use the command `whoami` to display your username.
+run the command `pwd`
+(short for "**p**rint **w**orking **d**irectory").
+This prints the absolute path of your **current working directory**,
+which is where the shell runs commands and looks for files by default.
 
 <hr>
-Run `pwd` in the shell window to the right.
+Run `pwd`.
 Where are you right now?
 
 *** =instructions
@@ -98,32 +89,30 @@ Unix systems typically place all users' home directories underneath `/home`.
 err = "That is not the correct path."
 correct = "Correct - you are in `/home/repl`."
 
-Ex() >> test_mc(3, [err, err, correct])
+Ex().has_chosen(3, [err, err, correct])
 ```
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:f5b0499835
 ## How can I identify files and directories?
 
-`pwd` tells you where you are,
-but doesn't tell you what files and directories are there.
-To find out,
-you can type `ls` (which is short for "listing") and press the enter key.
+`pwd` tells you where you are.
+To find out what's there,
+type `ls` (which is short for "listing") and press the enter key.
 On its own,
 `ls` lists the contents of your current directory
 (the one displayed by `pwd`).
-If you add the names of one or more files,
-`ls` will list those files,
+If you add the names of some files,
+`ls` will list them,
 and if you add the names of directories,
 it will list their contents.
 For example,
-typing `ls /home/repl` will show you the contents of your starting directory
-(usually called your **home directory**),
-which it also shows you if you are in that directory and type `ls` on its own.
+`ls /home/repl` shows you what's in your starting directory
+(usually called your **home directory**).
 
 <hr>
-Use `ls` with an appropriate argument to get a listing of the files in the directory `/home/repl/seasonal`
+Use `ls` with an appropriate argument to list the files in the directory `/home/repl/seasonal`
 (which holds information on dental surgeries by date, broken down by season).
-Which of the following files is *not* in that directory?
+Which of these files is *not* in that directory?
 
 *** =instructions
 - `autumn.csv`
@@ -143,7 +132,7 @@ If you give `ls` a path, it shows what's in that path.
 err = "That file is in the `seasonal` directory."
 correct = "Correct - that file is *not* in the `seasonal` directory."
 
-Ex() >> test_mc(2, [err, correct, err, err])
+Ex().has_chosen(2, [err, correct, err, err])
 ```
 
 --- type:BulletConsoleExercise key:a766184b59
@@ -197,9 +186,10 @@ ls course.txt
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['ls', '', {'course.txt'}]],
-                     msg='Use `ls` followed by a relative path.')
+Ex().multi(
+    has_cwd("/home/repl"),
+    has_expr_output(strict=True, incorrect_msg="Your command didn't generate the right output. Use `ls` followed by a relative path.")
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -228,9 +218,10 @@ ls seasonal/summer.csv
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['ls', '', {'seasonal/summer.csv'}]],
-                     msg='Use `ls` followed by a relative path.')
+Ex().multi(
+    has_cwd("/home/repl"),
+    has_expr_output(incorrect_msg="Have you used `ls seasonal/summer.csv`?")
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -259,10 +250,11 @@ ls people
 
 *** =sct3
 ```{python}
-import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['ls', '', re.compile('^people/?')]],
-                     msg='Use `ls` followed by the relative path to the directory.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_expr_output(incorrect_msg='Use `ls` followed by the relative path to the directory: `people`.')
+)
+Ex().success_msg("Well done. Now that you know about listing files and directories, let's see how you can move around the filesystem!")
 ```
 
 --- type:BulletConsoleExercise key:dbdaec5610
@@ -309,9 +301,7 @@ cd seasonal
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cd', '', re.compile(r'seasonal/?')]],
-                     msg='Use `cd` followed by a path.')
+Ex().has_cwd('/home/repl/seasonal', incorrect_msg="If your current working directory (find out with `pwd`) is `/home/repl`, you can move to the `seasonal` folder with `cd seasonal`.")
 ```
 
 *** =type2: ConsoleExercise
@@ -338,9 +328,10 @@ pwd
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['pwd']],
-                     msg='Remember: "print working directory".')
+Ex().multi(
+    has_cwd('/home/repl/seasonal'),
+    has_expr_output()
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -367,9 +358,12 @@ ls
 
 *** =sct3
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['ls']],
-                     msg='`ls` with no paths will show the contents of the current directory.')
+Ex().multi(
+    has_cwd('/home/repl/seasonal'),
+    has_expr_output(incorrect_msg="Your command did not generate the correct output. Have you used `ls` with no paths to show the contents of the current directory?")
+)
+
+Ex().success_msg("Neat! This was about navigating down to subdirectories. What about moving up? Let's find out!")
 ```
 
 --- type:PureMultipleChoiceExercise lang:shell xp:50 skills:1 key:09c717ef76
@@ -416,7 +410,7 @@ where does `cd ~/../.` take you?
 *** =hint
 Trace the path one directory at a time.
 
-*** =feedbacks
+*** =feedback
 - No, but either `~` or `..` on its own would take you there.
 - Correct! The path means 'home directory', 'up a level', 'here'.
 - No, but `.` on its own would do that.
@@ -459,7 +453,7 @@ copies *all* of the files into that directory.
 
 *** =instructions1
 
-Make a copy of `seasonal/summer.csv` in the `backup` directory,
+Make a copy of `seasonal/summer.csv` in the `backup` directory (which is also in `/home/repl`),
 calling the new file `summer.bck`.
 
 *** =hint1
@@ -478,9 +472,10 @@ cp seasonal/summer.csv backup/summer.bck
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cp', '', [re.compile('(./)?seasonal/summer.csv'), re.compile('(./)?backup/summer.bck')]]],
-                     msg='Provide two paths to `cp`.')
+Ex().check_correct(
+    check_file('/home/repl/backup/summer.bck', missing_msg="`summer.bck` doesn't appear to exist in the `backup` directory. Provide two paths to `cp`: the existing file (`seasonal/summer.csv`) and the destination file (`backup/summer.bck`)."),
+    has_cwd('/home/repl')
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -490,9 +485,8 @@ Ex() >> test_cmdline([['cp', '', [re.compile('(./)?seasonal/summer.csv'), re.com
 
 *** =instructions2
 
-You are in `/home/repl`, and there is a directory below it called `backup`.
-Copy `spring.csv` and `summer.csv` from the `seasonal` directory into `backup`
-*without* changing directory.
+Copy `spring.csv` and `summer.csv` from the `seasonal` directory into the `backup` directory
+*without* changing your current working directory (`/home/repl`).
 
 *** =hint2
 
@@ -510,11 +504,13 @@ cp seasonal/spring.csv seasonal/summer.csv backup
 
 *** =sct2
 ```{python}
-import re
-from shellwhat_ext import test_cmdline
-msg = 'Provide two filenames and a directory name to `cp`.'
-Ex() >> test_or(test_cmdline([['cp', '', ['seasonal/spring.csv', 'seasonal/summer.csv', re.compile(r'backup/?')]]], msg=msg),
-                test_cmdline([['cp', '', ['seasonal/summer.csv', 'seasonal/spring.csv', re.compile(r'backup/?')]]], msg=msg))
+patt = "`%s` doesn't appear to have been copied into the `backup` directory. Provide two filenames and a directory name to `cp`."
+Ex().multi(
+    has_cwd('/home/repl', incorrect_msg="Make sure to copy the files while in `{{dir}}`! Use `cd {{dir}}` to navigate back there."),
+    check_file('/home/repl/backup/spring.csv', missing_msg=patt%'spring.csv'),
+    check_file('/home/repl/backup/summer.csv', missing_msg=patt%'summer.csv')
+)
+Ex().success_msg("Good job. Other than copying, we should also be able to move files from one directory to another. Learn about it in the next exerise!")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:663a083a3c
@@ -537,8 +533,7 @@ up one level to its parent directory
 *** =instructions
 
 You are in `/home/repl`, which has sub-directories `seasonal` and `backup`.
-Using a single command,
-move `spring.csv` and `summer.csv` from `seasonal` to `backup`.
+Using a single command, move `spring.csv` and `summer.csv` from `seasonal` to `backup`.
 
 *** =solution
 ```{shell}
@@ -547,18 +542,21 @@ mv seasonal/spring.csv seasonal/summer.csv backup
 
 *** =sct
 ```{python}
-import re
-from shellwhat_ext import test_cmdline
-msg = 'Use two filenames and a directory name as parameters.'
-Ex() >> test_or(test_cmdline([['mv', '', ['seasonal/spring.csv', 'seasonal/summer.csv', re.compile(r'backup/?')]]], msg=msg),
-                test_cmdline([['mv', '', ['seasonal/summer.csv', 'seasonal/spring.csv', re.compile(r'backup/?')]]], msg=msg))
+backup_patt="The file `%s` is not in the `backup` directory. Have you used `mv` correctly? Use two filenames and a directory as parameters to `mv`."
+seasonal_patt="The file `%s` is still in the `seasonal` directory. Make sure to move the files with `mv` rather than copying them with `cp`!"
+Ex().multi(
+    check_file('/home/repl/backup/spring.csv', missing_msg=backup_patt%'spring.csv'),
+    check_file('/home/repl/backup/summer.csv', missing_msg=backup_patt%'summer.csv'),
+    check_not(check_file('/home/repl/seasonal/spring.csv'), incorrect_msg=seasonal_patt%'spring.csv'),
+    check_not(check_file('/home/repl/seasonal/summer.csv'), incorrect_msg=seasonal_patt%'summer.csv')
+)
+Ex().success_msg("Well done, let's keep this shell train going!")
 ```
 
 --- type:BulletConsoleExercise key:001801a652
 ## How can I rename files?
 
-`mv` can also be used to rename files.
-If you run:
+`mv` can also be used to rename files. If you run:
 
 ```{shell}
 mv course.txt old-course.txt
@@ -604,10 +602,7 @@ cd seasonal
 
 *** =sct1
 ```{python}
-import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cd', '', re.compile(r'seasonal/?')]],
-                     msg='Use `cd` to change directory.')
+Ex().has_cwd('/home/repl/seasonal')
 ```
 
 *** =type2: ConsoleExercise
@@ -634,9 +629,14 @@ mv winter.csv winter.csv.bck
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['mv', '', ['winter.csv', 'winter.csv.bck']]],
-                     msg='Use `mv` to rename a file.')
+hint = " Use `mv` with two arguments: the file you want to rename (`winter.csv`) and the new name for the file (`winter.csv.bck`)."
+Ex().multi(
+    has_cwd('/home/repl/seasonal'),
+    multi(
+        check_file('/home/repl/seasonal/winter.csv.bck', missing_msg="We expected to find `winter.csv.bck` in the directory." + hint),
+        check_not(check_file('/home/repl/seasonal/winter.csv'), incorrect_msg="We were no longer expecting `winter.csv` to be in the directory." + hint)
+    )
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -663,9 +663,11 @@ ls
 
 *** =sct3
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['ls']],
-                     msg='Use `ls` to list the directory contents.')
+Ex().multi(
+    has_cwd('/home/repl/seasonal'),
+    has_expr_output(incorrect_msg="Have you used `ls` to list the contents of your current working directory?")
+)
+Ex().success_msg("Copying, moving, renaming, you've all got it figured out! Next up: deleting files.")
 ```
 
 --- type:BulletConsoleExercise key:2734680614
@@ -720,10 +722,7 @@ cd seasonal
 
 *** =sct1
 ```{python}
-import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cd', '', re.compile(r'seasonal/?')]],
-                     msg='Use `cd` to change directory.')
+Ex().has_cwd('/home/repl/seasonal')
 ```
 
 *** =type2: ConsoleExercise
@@ -750,9 +749,10 @@ rm autumn.csv
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['rm', '', 'autumn.csv']],
-                     msg='Use `rm` to remove a single file.')
+Ex().multi(
+    has_cwd('/home/repl/seasonal'),
+    check_not(check_file('/home/repl/seasonal/autumn.csv'), incorrect_msg="We weren't expecting `autumn.csv` to still be in the `seasonal` directory. Use `rm` with the path to the file you want to remove.")
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -779,9 +779,7 @@ cd
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'\s*cd(\s+(\.\.|\~))?\s*',
-                           fixed=False,
-                           msg='Use `cd ..` to go up a level or `cd ~` to return home.')
+Ex().has_cwd('/home/repl', incorrect_msg="Use `cd` or `cd ~` to retrun back to the home directory")
 ```
 
 *** =type4: ConsoleExercise
@@ -808,9 +806,11 @@ rm seasonal/summer.csv
 
 *** =sct4
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['rm', '', re.compile('(./)?seasonal/summer.csv')]],
-                     msg='`rm` also works with paths! So try removing `summer.csv` without getting inside `seasonal`.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_not(check_file('/home/repl/seasonal/summer.csv'), incorrect_msg="`summer.csv` should no longer be be in the `seasonal` directory. Have you used `rm` correctly?")
+)
+Ex().success_msg("Impressive stuff! Off to the next one!")
 ```
 
 --- type:BulletConsoleExercise key:63e8fbd0c2
@@ -863,9 +863,10 @@ rm people/agarwal.txt
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['rm', '', 'people/agarwal.txt']],
-                     msg='Remove the file inside `people`.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_not(check_file('/home/repl/people/agarwal.txt'), incorrect_msg="`agarwal.txt` should no longer be in `/home/repl/people`. Have you used `rm` correctly?")
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -893,10 +894,11 @@ rmdir people
 
 *** =sct2
 ```{python}
-import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['rmdir', '', re.compile('people/?')]],
-                     msg='Remove the directory `people`.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_not(has_dir('/home/repl/people'),
+              incorrect_msg = "The 'people' directory should no longer be in your home directory. Use `rmdir` to remove it!")
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -926,9 +928,10 @@ mkdir yearly
 
 *** =sct3
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['mkdir', '', 'yearly']],
-                     msg='Make the upper directory.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_dir('/home/repl/yearly', incorrect_msg="There is no `yearly` directiory in your home directory. Use `mkdir yearly` to create one!")
+)
 ```
 
 *** =type4: ConsoleExercise
@@ -957,9 +960,12 @@ mkdir yearly/2017
 
 *** =sct4
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['mkdir', '', 'yearly/2017']],
-                     msg='Make the lower directory using a relative path.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_dir('/home/repl/yearly/2017',
+            incorrect_msg="Cannot find a '2017' directory in '/home/repl/yearly'. You can create this directory using the relative path `yearly/2017`.")
+)
+Ex().success_msg("Cool! Let's wrap up this chapter with an exercise that repeats some of its concepts!")
 ```
 
 --- type:BulletConsoleExercise key:b1990e9a42
@@ -1000,10 +1006,7 @@ cd /tmp
 
 *** =sct1
 ```{python}
-import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cd', '', re.compile(r'^/tmp/?')]],
-                     msg='Change your directory to `/tmp`.')
+Ex().has_cwd('/tmp')
 ```
 
 
@@ -1030,9 +1033,10 @@ ls
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['ls']],
-                     msg='Use `ls` to see what files and directories you have.')
+Ex().multi(
+    has_cwd('/tmp'),
+    has_code('^\s*ls', incorrect_msg="Have you used `ls`, simply to list the files in `/tmp`, your current working directory?")
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -1057,9 +1061,10 @@ mkdir scratch
 
 *** =sct3
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['mkdir', '', re.compile('(./)?scratch')]],
-                     msg='Use `mkdir` followed by the relative path of the directory you want to create.')
+Ex().multi(
+    has_cwd('/tmp'),
+    has_dir('/tmp/scratch', incorrect_msg="Cannot find a 'scratch' directory under '/tmp'. Make sure to use `mkdir` correctly.")
+)
 ```
 
 *** =type4: ConsoleExercise
@@ -1068,10 +1073,8 @@ Ex() >> test_cmdline([['mkdir', '', re.compile('(./)?scratch')]],
 *** =xp4: 30
 
 *** =instructions4
-Move `/home/repl/people/agarwal.txt` into `/tmp`
-using the `~` shortcut for your home directory
-and a relative path for the second
-rather than the absolute path `/home/repl/tmp`.
+Move `/home/repl/people/agarwal.txt` into `/tmp/scratch`.
+We suggest you use the `~` shortcut for your home directory and a relative path for the second rather than the absolute path.
 
 *** =sample_code4
 ```{shell}
@@ -1079,13 +1082,14 @@ rather than the absolute path `/home/repl/tmp`.
 
 *** =solution4
 ```{shell}
-mv ~/people/agarwal.txt .
+mv ~/people/agarwal.txt scratch
 ```
 
 *** =sct4
 ```{python}
-import re
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['mv', '', ['~/people/agarwal.txt', re.compile(r'^./?')]]],
-                     msg='Use `~/people/agarwal.txt` for the first parameter and `.` for the second.')
+Ex().multi(
+    has_cwd('/tmp'),
+    check_file('/tmp/scratch/agarwal.txt', missing_msg="Cannot find 'agarwal.txt' in '/tmp/scratch'. Use `mv` with `~/people/agarwal.txt` as the first parameter and `scratch` as the second.")
+)
+Ex().success_msg("This concludes chapter 1 of the intro to Shell for Data Science course! Rush over to the next chapter to learn more about manipulating data!")
 ```

--- a/chapter1.md
+++ b/chapter1.md
@@ -623,7 +623,10 @@ cd seasonal
 
 *** =sct1
 ```{python}
-Ex().has_cwd('/home/repl/seasonal')
+Ex().check_correct(
+  has_cwd('/home/repl/seasonal'),
+  has_code('cd +seasonal', incorrect_msg="If your current working directory (find out with `pwd`) is `/home/repl`, you can move to the `seasonal` folder with `cd seasonal`.")
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -687,6 +690,13 @@ ls
 Ex().multi(
     has_cwd('/home/repl/seasonal'),
     has_expr_output(incorrect_msg="Have you used `ls` to list the contents of your current working directory?")
+)
+Ex().multi(
+    has_cwd("/home/repl/seasonal"),
+    check_correct(
+      has_expr_output(strict=True),
+      has_code("ls", incorrect_msg = "Your command didn't generate the correct file listing. Use `ls` without arguments to list the contents of your current working directory.")
+    )
 )
 Ex().success_msg("Copying, moving, renaming, you've all got it figured out! Next up: deleting files.")
 ```

--- a/chapter1.md
+++ b/chapter1.md
@@ -97,7 +97,7 @@ Ex().has_chosen(3, [err, err, correct])
 
 `pwd` tells you where you are.
 To find out what's there,
-type `ls` (which is short for "listing") and press the enter key.
+type `ls` (which is short for "**l**i**s**ting") and press the enter key.
 On its own,
 `ls` lists the contents of your current directory
 (the one displayed by `pwd`).
@@ -139,7 +139,7 @@ Ex().has_chosen(2, [err, correct, err, err])
 ## How else can I identify files and directories?
 
 An absolute path is like a latitude and longitude:
-it specifies the same thing no matter where you are.
+it has the same value no matter where you are.
 A **relative path**,
 on the other hand,
 specifies a location starting from where you are:
@@ -188,7 +188,11 @@ ls course.txt
 ```{python}
 Ex().multi(
     has_cwd("/home/repl"),
-    has_expr_output(strict=True, incorrect_msg="Your command didn't generate the right output. Use `ls` followed by a relative path.")
+    has_code("ls", incorrect_msg = "You didn't call `ls` to generate the file listing."), # to prevent `echo "course.txt"`
+    check_correct(
+      has_expr_output(strict=True),
+      has_code("ls +course.txt", incorrect_msg = "Your command didn't generate the correct file listing. Use `ls` followed by a relative path to `/home/repl/course.txt`.")
+    )
 )
 ```
 
@@ -220,7 +224,11 @@ ls seasonal/summer.csv
 ```{python}
 Ex().multi(
     has_cwd("/home/repl"),
-    has_expr_output(incorrect_msg="Have you used `ls seasonal/summer.csv`?")
+    has_code("ls", incorrect_msg = "You didn't call `ls` to generate the file listing."), 
+    check_correct(
+      has_expr_output(strict=True),
+      has_code("ls +seasonal/summer.csv", incorrect_msg = "Your command didn't generate the correct file listing. Use `ls` followed by a relative path to `/home/repl/seasonal/summer.csv`.")
+    )
 )
 ```
 
@@ -251,8 +259,12 @@ ls people
 *** =sct3
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    has_expr_output(incorrect_msg='Use `ls` followed by the relative path to the directory: `people`.')
+    has_cwd("/home/repl"),
+    has_code("ls", incorrect_msg = "You didn't call `ls` to generate the file listing."), 
+    check_correct(
+      has_expr_output(strict=True),
+      has_code("ls +people", incorrect_msg = "Your command didn't generate the correct file listing. Use `ls` followed by a relative path to `/home/repl/people`.")
+    )
 )
 Ex().success_msg("Well done. Now that you know about listing files and directories, let's see how you can move around the filesystem!")
 ```

--- a/chapter1.md
+++ b/chapter1.md
@@ -782,7 +782,8 @@ rm autumn.csv
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/seasonal'),
-    check_not(check_file('/home/repl/seasonal/autumn.csv'), incorrect_msg="We weren't expecting `autumn.csv` to still be in the `seasonal` directory. Use `rm` with the path to the file you want to remove.")
+    check_not(check_file('/home/repl/seasonal/autumn.csv'), incorrect_msg="We weren't expecting `autumn.csv` to still be in the `seasonal` directory. Use `rm` with the path to the file you want to remove."),
+    has_code('rm', incorrect_msg = 'Use `rm` to remove the file, rather than moving it.')
 )
 ```
 
@@ -810,7 +811,7 @@ cd
 
 *** =sct3
 ```{python}
-Ex().has_cwd('/home/repl', incorrect_msg="Use `cd` or `cd ~` to retrun back to the home directory")
+Ex().has_cwd('/home/repl', incorrect_msg="Use `cd ..` or `cd ~` to return to the home directory.")
 ```
 
 *** =type4: ConsoleExercise
@@ -839,7 +840,8 @@ rm seasonal/summer.csv
 ```{python}
 Ex().multi(
     has_cwd('/home/repl'),
-    check_not(check_file('/home/repl/seasonal/summer.csv'), incorrect_msg="`summer.csv` should no longer be be in the `seasonal` directory. Have you used `rm` correctly?")
+    check_not(check_file('/home/repl/seasonal/summer.csv'), incorrect_msg="We weren't expecting `summer.csv` to still be in the `seasonal` directory. Use `rm` with the path to the file you want to remove."),
+    has_code('rm', incorrect_msg = 'Use `rm` to remove the file, rather than moving it.')
 )
 Ex().success_msg("Impressive stuff! Off to the next one!")
 ```

--- a/chapter1.md
+++ b/chapter1.md
@@ -313,7 +313,10 @@ cd seasonal
 
 *** =sct1
 ```{python}
-Ex().has_cwd('/home/repl/seasonal', incorrect_msg="If your current working directory (find out with `pwd`) is `/home/repl`, you can move to the `seasonal` folder with `cd seasonal`.")
+Ex().check_correct(
+  has_cwd('/home/repl/seasonal'),
+  has_code('cd +seasonal', incorrect_msg="If your current working directory (find out with `pwd`) is `/home/repl`, you can move to the `seasonal` folder with `cd seasonal`.")
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -342,7 +345,10 @@ pwd
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/seasonal'),
-    has_expr_output()
+    check_correct(
+      has_expr_output(),
+      has_code('pwd')
+    )
 )
 ```
 
@@ -372,7 +378,10 @@ ls
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/seasonal'),
-    has_expr_output(incorrect_msg="Your command did not generate the correct output. Have you used `ls` with no paths to show the contents of the current directory?")
+    check_correct(
+      has_expr_output(),
+      has_code('ls', incorrect_msg="Your command did not generate the correct output. Have you used `ls` with no paths to show the contents of the current directory?")
+    )
 )
 
 Ex().success_msg("Neat! This was about navigating down to subdirectories. What about moving up? Let's find out!")

--- a/chapter1.md
+++ b/chapter1.md
@@ -1040,7 +1040,10 @@ cd /tmp
 
 *** =sct1
 ```{python}
-Ex().has_cwd('/tmp')
+Ex().check_correct(
+  has_cwd('/tmp'),
+  has_code('cd +/tmp', incorrect_msg = 'You are in the wrong directory. Use `cd` to change directory to `/tmp`.')
+)
 ```
 
 
@@ -1068,8 +1071,12 @@ ls
 *** =sct2
 ```{python}
 Ex().multi(
-    has_cwd('/tmp'),
-    has_code('^\s*ls', incorrect_msg="Have you used `ls`, simply to list the files in `/tmp`, your current working directory?")
+    has_cwd("/tmp"),
+    has_code("ls", incorrect_msg = "You didn't call `ls` to generate the file listing."),
+    check_correct(
+      has_expr_output(strict=True),
+      has_code("^\s*ls\s*$", incorrect_msg = "Your command didn't generate the correct file listing. Use `ls` without`.")
+    )
 )
 ```
 
@@ -1097,7 +1104,10 @@ mkdir scratch
 ```{python}
 Ex().multi(
     has_cwd('/tmp'),
-    has_dir('/tmp/scratch', incorrect_msg="Cannot find a 'scratch' directory under '/tmp'. Make sure to use `mkdir` correctly.")
+    check_correct(
+      has_dir('/tmp/scratch'),
+      has_code('mkdir +scratch', incorrect_msg="Cannot find a 'scratch' directory under '/tmp'. Make sure to use `mkdir` correctly.")
+    )
 )
 ```
 

--- a/chapter1.md
+++ b/chapter1.md
@@ -898,7 +898,8 @@ rm people/agarwal.txt
 ```{python}
 Ex().multi(
     has_cwd('/home/repl'),
-    check_not(check_file('/home/repl/people/agarwal.txt'), incorrect_msg="`agarwal.txt` should no longer be in `/home/repl/people`. Have you used `rm` correctly?")
+    check_not(check_file('/home/repl/people/agarwal.txt'), incorrect_msg="`agarwal.txt` should no longer be in `/home/repl/people`. Have you used `rm` correctly?"),
+    has_expr_output(expr = 'ls people', output = '', incorrect_msg = 'There are still files in the `people` directory. If you simply moved `agarwal.txt`, or created new files, delete them all.')
 )
 ```
 
@@ -963,7 +964,7 @@ mkdir yearly
 ```{python}
 Ex().multi(
     has_cwd('/home/repl'),
-    has_dir('/home/repl/yearly', incorrect_msg="There is no `yearly` directiory in your home directory. Use `mkdir yearly` to create one!")
+    has_dir('/home/repl/yearly', incorrect_msg="There is no `yearly` directory in your home directory. Use `mkdir yearly` to make one!")
 )
 ```
 
@@ -996,7 +997,7 @@ mkdir yearly/2017
 Ex().multi(
     has_cwd('/home/repl'),
     has_dir('/home/repl/yearly/2017',
-            incorrect_msg="Cannot find a '2017' directory in '/home/repl/yearly'. You can create this directory using the relative path `yearly/2017`.")
+            incorrect_msg="Cannot find a '2017' directory in '/home/repl/yearly'. You can make this directory using the relative path `yearly/2017`.")
 )
 Ex().success_msg("Cool! Let's wrap up this chapter with an exercise that repeats some of its concepts!")
 ```

--- a/chapter2.md
+++ b/chapter2.md
@@ -550,7 +550,7 @@ Pay attention to the trailing colon.
 
 *** =sct
 ```{python}
-Ex().has_chosen(3, ['No, there is more.', 'No, there is more.', 'Correct!', 'No, `cut` does the best it can.'])
+Ex().has_chosen(3, ['No, there is more.', 'No, there is more.', 'Correct! The trailing colon creates an empty fourth field.', 'No, `cut` does the best it can.'])
 ```
 
 --- type:TabConsoleExercise key:32c0d30049

--- a/chapter2.md
+++ b/chapter2.md
@@ -315,6 +315,10 @@ Run `ls` with the two flags, `-R` and `-F`, and the absolute path to your home d
 to see everything it contains.
 (The order of the flags doesn't matter, but the directory name must come last.)
 
+*** =hint
+
+Your home directory can be specified using `~` or `.` or its absolute path.
+
 *** =solution
 ```{shell}
 ls -R -F /home/repl

--- a/chapter2.md
+++ b/chapter2.md
@@ -633,7 +633,10 @@ cd seasonal
 
 *** =sct2
 ```{python}
-Ex().has_cwd('/home/repl/seasonal', incorrect_msg="You are not in the `seasonal` directory. Try again.")
+Ex().check_correct(
+  has_cwd('/home/repl/seasonal'),
+  has_code('cd +seasonal', incorrect_msg="If your current working directory (find out with `pwd`) is `/home/repl`, you can move to the `seasonal` folder with `cd seasonal`.")
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -701,7 +704,7 @@ history
 
 *** =sct4
 ```{python}
-Ex().has_code(r'history', incorrect_msg='Use `history` to get a list.')
+Ex().has_code(r'history', incorrect_msg='Use `history` without flags to get a list of previous commands.')
 ```
 
 *** =type5: ConsoleExercise
@@ -737,7 +740,11 @@ Ex().multi(
     check_or(
         has_expr_output(expr = 'head summer.csv',
                         incorrect_msg='Have you used `!<a_number>` to rerun the last `head` from the history?'),
-        has_code(r'!3')
+        # The head cmd should appear twice, at positions 1 and 3, though this will change 
+        # if the student typed a wrong answer.
+        # Since we're also checking output, this should be niche enough to ignore.
+        has_code(r'!3'),
+        has_code(r'!1') 
     )
 )
 Ex().success_msg("Well done! To the next one!")

--- a/chapter2.md
+++ b/chapter2.md
@@ -489,7 +489,7 @@ The order of the flags doesn't matter.
 
 *** =sct
 ```{python}
-Ex().has_chosen(3, ['Yes, but that is not all', 'Yes, but that is not all', 'Correct!', 'No, flag order doesn\'t matter'])
+Ex().has_chosen(3, ['Yes, but that is not all', 'Yes, but that is not all', 'Correct! Adding a space after the flag is good style, but not compulsory.', 'No, flag order doesn\'t matter'])
 ```
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:b9bb10ae87

--- a/chapter2.md
+++ b/chapter2.md
@@ -785,10 +785,8 @@ What's more important right now is some of `grep`'s more common flags:
 
 *** =instructions1
 
-Find all of the lines containing the word `molar` in `seasonal/autumn.csv`
-by running a single command while in your home directory.
-Again, it's considered good practice to put flags and arguments before filenames,
-so this course only accepts solutions that do that.
+Print the contents of all of the lines containing the word `molar` in `seasonal/autumn.csv`
+by running a single command while in your home directory. Don't use any flags.
 
 *** =hint1
 
@@ -806,8 +804,15 @@ grep molar seasonal/autumn.csv
 *** =sct1
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    has_expr_output()
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(),
+    multi(
+      has_code("grep", incorrect_msg = "Did you call `grep`?"),
+      has_code("molar", incorrect_msg = "Did you search for `molar`?"),
+      has_code("seasonal/autumn.csv", incorrect_msg = "Did you search the `seasonal/autumn.csv` file?")
+    )
+  )
 )
 ```
 
@@ -818,11 +823,8 @@ Ex().multi(
 
 *** =instructions2
 
-Find all of the lines that *don't* contain the word `molar` in `seasonal/spring.csv`, and show their line numbers.
-Remember,
-it's considered good style to put all of the flags *before* other values like filenames or the search term "molar",
-so in this course,
-we only accept answers that do that.
+Invert the match to find all of the lines that *don't* contain the word `molar` in `seasonal/spring.csv`, and show their line numbers.
+Remember, it's considered good style to put all of the flags *before* other values like filenames or the search term "molar".
 
 *** =hint3
 
@@ -840,8 +842,17 @@ grep -v -n molar seasonal/spring.csv
 *** =sct2
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    has_expr_output()
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(),
+    multi(
+      has_code("grep", incorrect_msg = "Did you call `grep`?"),
+      has_code("-v", incorrect_msg = "Did you invert the match with `-v`?"),
+      has_code("-n", incorrect_msg = "Did you show line numbers with `-n`?"),
+      has_code("molar", incorrect_msg = "Did you search for `molar`?"),
+      has_code("seasonal/spring.csv", incorrect_msg = "Did you search the `seasonal/spring.csv` file?")
+    )
+  )
 )
 ```
 
@@ -872,8 +883,17 @@ grep -c incisor seasonal/autumn.csv seasonal/winter.csv
 *** =sct3
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    has_expr_output()
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(),
+    multi(
+      has_code("grep", incorrect_msg = "Did you call `grep`?"),
+      has_code("-c", incorrect_msg = "Did you get counts with `-c`?"),
+      has_code("incisor", incorrect_msg = "Did you search for `incisor`?"),
+      has_code("seasonal/autumn.csv", incorrect_msg = "Did you search the `seasonal/autumn.csv` file?"),
+      has_code("seasonal/winter.csv", incorrect_msg = "Did you search the `seasonal/winter.csv` file?")
+    )
+  )
 )
 ```
 

--- a/chapter2.md
+++ b/chapter2.md
@@ -593,7 +593,7 @@ head summer.csv
 ```{python}
 Ex().multi(
     has_cwd('/home/repl'),
-    has_code('\s*head\s+summer.csv\s*', incorrect_msg="Use `head` and a filename, `summer.csv`. Don't worry if it fails. It should.")
+    has_code(r'\s*head\s+summer.csv\s*', incorrect_msg="Use `head` and a filename, `summer.csv`. Don't worry if it fails. It should.")
 )
 ```
 
@@ -693,7 +693,7 @@ history
 
 *** =sct4
 ```{python}
-Ex().has_code('history', incorrect_msg='Use `history` to get a list.')
+Ex().has_code(r'history', incorrect_msg='Use `history` to get a list.')
 ```
 
 *** =type5: ConsoleExercise
@@ -729,7 +729,7 @@ Ex().multi(
     check_or(
         has_expr_output(expr = 'head summer.csv',
                         incorrect_msg='Have you used `!<a_number>` to rerun the last `head` from the history?'),
-        has_code('!3')
+        has_code(r'!3')
     )
 )
 Ex().success_msg("Well done! To the next one!")

--- a/chapter2.md
+++ b/chapter2.md
@@ -15,7 +15,7 @@ you may want to have a look at their contents.
 The simplest way to do this is with `cat`,
 which just prints the contents of files onto the screen.
 (Its name is short for "concatenate", meaning "to link things together",
-since it will print all the files whose names you give it, one after the other).
+since it will print all the files whose names you give it, one after the other.)
 
 ```{shell}
 cat agarwal.txt

--- a/chapter2.md
+++ b/chapter2.md
@@ -274,7 +274,8 @@ Ex().multi(
     check_correct(
         has_expr_output(incorrect_msg="Are you sure you're calling `head` on the `seasonal/winter.csv` file?"),
         has_expr_output(strict=True, incorrect_msg="Are you sure you used the flag `-n 5`?")
-    )
+    ),
+    check_not(has_output("2017-02-17,incisor"), incorrect_msg = "Are you sure you used the flag `-n 5`?")
 )
 Ex().success_msg("Nice! With this technique, you can avoid your shell from blowing up if you want to have a look at larger text files.")
 ```

--- a/chapter2.md
+++ b/chapter2.md
@@ -322,7 +322,10 @@ ls -R -F /home/repl
 
 *** =sct
 ```{python}
-Ex().has_expr_output(incorrect_msg='Use either `ls -R -F` or `ls -F -R` and the path `/home/repl`.')
+Ex().check_or(
+  has_expr_output(incorrect_msg='Use either `ls -R -F` or `ls -F -R` and the path `/home/repl`.'),
+  has_expr_output(expr = "ls -R -F .", incorrect_msg='Use either `ls -R -F` or `ls -F -R` and the path `/home/repl`.')
+)
 Ex().success_msg("That's a pretty neat overview, isn't it?")
 ```
 

--- a/chapter2.md
+++ b/chapter2.md
@@ -14,8 +14,8 @@ Before you rename or delete files,
 you may want to have a look at their contents.
 The simplest way to do this is with `cat`,
 which just prints the contents of files onto the screen.
-(Its name is short for "concatenate",
-since it will print all the files whose names you give it).
+(Its name is short for "concatenate", meaning "to link things together",
+since it will print all the files whose names you give it, one after the other).
 
 ```{shell}
 cat agarwal.txt

--- a/chapter2.md
+++ b/chapter2.md
@@ -38,9 +38,11 @@ cat course.txt
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cat', '', 'course.txt']],
-                     msg='Type `cat` followed by the name of the file.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_expr_output(incorrect_msg="Your command didn't generate the right output. Have you used `cat` followed by the name of the file, `course.txt`?")
+)
+Ex().success_msg("Nice! Let's look at other ways to view a file's contents.")
 ```
 
 --- type:ConsoleExercise xp:100 key:d8a30a3f81
@@ -71,16 +73,20 @@ Press spacebar to page down, `:n` to go to the second file, and `:q` to quit.
 
 *** =solution
 ```{bash}
-# Run the following command *without* '| cat':
+# You can leave out the '| cat' part here:
 less seasonal/spring.csv seasonal/summer.csv | cat
 ```
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_student_typed(r'\s*less\s+seasonal/spring\.csv\s+seasonal/summer\.csv\s*',
-                           fixed=False,
-                           msg='Use `less` and the filenames.  Remember that `:n` moves you to the next file.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_or(
+        has_code(r'\s*less\s+seasonal/spring\.csv\s+seasonal/summer\.csv\s*',
+                 incorrect_msg='Use `less` and the filenames. Remember that `:n` moves you to the next file.'),
+        has_code(r'\s*less\s+seasonal/summer\.csv\s+seasonal/spring\.csv\s*')
+    )
+)
 ```
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:82bdc9af65
@@ -137,7 +143,7 @@ What is the most useful thing it could do?
 
 *** =sct
 ```{shell}
-Ex() >> test_mc(2, ["Incorrect: that isn't the most useful thing it could do.",
+Ex().has_chosen(2, ["Incorrect: that isn't the most useful thing it could do.",
                     "Correct!",
                     "Incorrect: that would be impossible to distinguish from a file that ended with a bunch of blank lines."])
 ```
@@ -189,9 +195,10 @@ head seasonal/autumn.csv
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['head', '', 'seasonal/autumn.csv']],
-                     msg='Type `head s`, a tab, `a`, and a tab.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_expr_output(incorrect_msg="The checker couldn't find the right output in your command. Are you sure you called `head` on `seasonal/autumn.csv`?")
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -218,9 +225,11 @@ head seasonal/spring.csv
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['head', '', 'seasonal/spring.csv']],
-                     msg='Type `head s`, a tab, `sp`, and a tab.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_expr_output(incorrect_msg="The checker couldn't find the right output in your command. Are you sure you called `head` on `seasonal/spring.csv`?")
+)
+Ex().success_msg("Good work! Once you get used to using tab completion, it will save you a lot of time!")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:9eb608f6c9
@@ -260,9 +269,14 @@ head -n 5 seasonal/winter.csv
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['head', 'n:', 'seasonal/winter.csv', {'-n': '5'}]],
-                     msg='Use `head` with `-n` and the number of lines you want.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_correct(
+        has_expr_output(incorrect_msg="Are you sure you're calling `head` on the `seasonal/winter.csv` file?"),
+        has_expr_output(strict=True, incorrect_msg="Are you sure you used the flag `-n 5`?")
+    )
+)
+Ex().success_msg("Nice! With this technique, you can avoid your shell from blowing up if you want to have a look at larger text files.")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:f830d46419
@@ -307,9 +321,8 @@ ls -R -F /home/repl
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['ls', 'RF', re.compile(r'^(~|/home/repl)/?$')]],
-                     msg='Use either `ls -R -F` or `ls -F -R` and the path `/home/repl`.')
+Ex().has_expr_output(incorrect_msg='Use either `ls -R -F` or `ls -F -R` and the path `/home/repl`.')
+Ex().success_msg("That's a pretty neat overview, isn't it?")
 ```
 
 --- type:BulletConsoleExercise key:7b90b8a7cd
@@ -393,9 +406,7 @@ man tail | cat
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*man\s+tail.*',
-                           fixed=False,
-                           msg='Use `man` and the command name.')
+Ex().has_code(r'\s*man\s+tail.*', incorrect_msg='Use `man` and the command name.')
 ```
 
 *** =type2: ConsoleExercise
@@ -405,8 +416,7 @@ Ex() >> test_student_typed(r'\s*man\s+tail.*',
 
 *** =instructions2
 
-Use `tail` with `-n` and a number with a leading `+`
-to display all *but* the first six lines of `seasonal/spring.csv`.
+Use `tail` with the flag `-n +7` to display all *but* the first six lines of `seasonal/spring.csv`.
 
 *** =hint2
 
@@ -423,9 +433,11 @@ tail -n +7 seasonal/spring.csv
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['tail', 'n:', re.compile(r'^(~/)?seasonal/spring.csv$'), {'-n' : '+7'}]],
-                     msg='`man` told you that using the `-n` flag with `+NUMBER` will display lines starting from NUMBER.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_output('2017-09-07,molar', incorrect_msg="Are you calling `tail` on `seasonal/spring.csv`?"),
+    has_expr_output(strict=True, incorrect_msg="Are you share you used the flag `-n +7`?")
+)
 ```
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:925e9d645a
@@ -469,7 +481,7 @@ The order of the flags doesn't matter.
 
 *** =sct
 ```{python}
-Ex() >> test_mc(3, ['Yes, but that is not all', 'Yes, but that is not all', 'Correct!', 'No, flag order doesn\'t matter'])
+Ex().has_chosen(3, ['Yes, but that is not all', 'Yes, but that is not all', 'Correct!', 'No, flag order doesn\'t matter'])
 ```
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:b9bb10ae87
@@ -530,7 +542,7 @@ Pay attention to the trailing colon.
 
 *** =sct
 ```{python}
-Ex() >> test_mc(3, ['No, there is more.', 'No, there is more.', 'Correct!', 'No, `cut` does the best it can.'])
+Ex().has_chosen(3, ['No, there is more.', 'No, there is more.', 'Correct!', 'No, `cut` does the best it can.'])
 ```
 
 --- type:TabConsoleExercise key:32c0d30049
@@ -579,9 +591,10 @@ head summer.csv
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['head', '', 'summer.csv']],
-                     msg='Use `head` and a filename.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_code('\s*head\s+summer.csv\s*', incorrect_msg="Use `head` and a filename, `summer.csv`. Don't worry if it fails. It should.")
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -612,9 +625,7 @@ cd seasonal
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cd', '', re.compile(r'seasonal/?$')]],
-                     msg='Use `cd` and a directory name.')
+Ex().has_cwd('/home/repl/seasonal', incorrect_msg="You are not in the `seasonal` directory. Try again.")
 ```
 
 *** =type3: ConsoleExercise
@@ -626,7 +637,7 @@ You can now repeat your previous `head` command without retyping it.
 
 *** =instructions3
 
-Re-run the `head` command using `!` followed by the command name.
+Re-run the `head` command with `!head`.
 
 *** =hint3
 
@@ -643,10 +654,16 @@ Do not type any spaces between `!` and what follows.
 
 *** =sct3
 ```{python}
-# FIXME: bodging the SCT to get a pass.
-Ex() >> test_student_typed(r'\s*.+\s*',
-                           fixed=False,
-                           msg='Use `!` followed by the name of the command.')
+# !head is expanded into head summer.csv by the terminal, so manually specify expression
+# This won't work for the validator though, so we have to use check_or to satisfy it.
+Ex().multi(
+    has_cwd('/home/repl/seasonal'),
+    check_or(
+        has_expr_output(expr = 'head summer.csv',
+                        incorrect_msg='Use `!head` to repeat the `head` command.'),
+        has_code('!head')
+    )
+)
 ```
 
 *** =type4: ConsoleExercise
@@ -676,9 +693,7 @@ history
 
 *** =sct4
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['history']],
-                     msg='Use `history` to get a list.')
+Ex().has_code('history', incorrect_msg='Use `history` to get a list.')
 ```
 
 *** =type5: ConsoleExercise
@@ -707,14 +722,21 @@ Do *not* type any spaces between `!` and what follows.
 
 *** =sct5
 ```{python}
-# FIXME: bodging the SCT to get a pass.
-Ex() >> test_student_typed(r'\s*.+\s*',
-                           fixed=False,
-                           msg='Use `!` followed by a number.')
+# !3 is expanded into head summer.csv by the terminal, so manually specify expression
+# This won't work for the validator though, so we have to use check_or to satisfy it.
+Ex().multi(
+    has_cwd('/home/repl/seasonal'),
+    check_or(
+        has_expr_output(expr = 'head summer.csv',
+                        incorrect_msg='Have you used `!<a_number>` to rerun the last `head` from the history?'),
+        has_code('!3')
+    )
+)
+Ex().success_msg("Well done! To the next one!")
 ```
 
 --- type:BulletConsoleExercise key:adf1516acf
-## How can I select lines containing particular values?
+## How can I select lines containing specific values?
 
 `head` and `tail` select rows,
 `cut` selects columns,
@@ -768,9 +790,10 @@ grep molar seasonal/autumn.csv
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['grep', '', ['molar', re.compile(r'^([.~]/)?seasonal/autumn.csv')]]],
-                     msg='Use the relative path to the file to search.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_expr_output()
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -801,9 +824,10 @@ grep -v -n molar seasonal/spring.csv
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['grep', 'vn', ['molar', re.compile(r'([.~]/)?seasonal/spring.csv')], {'-v': None, '-n': None}]],
-                     msg='Use `-v` and `-n` in either order. Don\'t forget to use the spring data.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_expr_output()
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -832,10 +856,10 @@ grep -c incisor seasonal/autumn.csv seasonal/winter.csv
 
 *** =sct3
 ```{python}
-from shellwhat_ext import test_cmdline
-msg = 'Use `-c` to get a count.'
-Ex() >> test_or(test_cmdline([['grep', 'c', ['incisor', re.compile(r'([.~]/)?seasonal/autumn.csv'), re.compile(r'([.~]/)?seasonal/winter.csv')], {'-c': None}]], msg=msg),
-                test_cmdline([['grep', 'c', ['incisor', re.compile(r'([.~]/)?seasonal/winter.csv'), re.compile(r'([.~]/)?seasonal/autumn.csv')], {'-c': None}]], msg=msg))
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_expr_output()
+)
 ```
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:11914639fc
@@ -870,5 +894,5 @@ would it produce the right answer?
 err1 = 'True, but it is not necessarily an error.'
 correct2 = 'Correct: joining the lines with columns creates only one empty column at the start, not two.'
 err3 = 'No, all of the winter data is there.'
-Ex() >> test_mc(2, [err1, correct2, err3])
+Ex().has_chosen(2, [err1, correct2, err3])
 ```

--- a/chapter3.md
+++ b/chapter3.md
@@ -494,6 +494,10 @@ cut -d , -f 2 seasonal/winter.csv | grep -v Tooth
 
 Extend it with a `sort` command, and use `uniq -c` to display unique lines with a count of how often each occurs rather than using `uniq` and `wc`.
 
+*** =hint
+
+Copy and paste the command in the instructions, pipe to `sort` without flags, then pipe again to `uniq` with a `-c` flag.
+
 *** =solution
 ```{shell}
 cut -d , -f 2 seasonal/winter.csv | grep -v Tooth | sort | uniq -c
@@ -509,7 +513,8 @@ Ex().multi(
             has_code('cut\s+-d\s+,\s+-f\s+2\s+seasonal/winter.csv\s+\|\s+grep\s+-v\s+Tooth',
                      incorrect_msg="You should start from this command: `cut -d , -f 2 seasonal/winter.csv | grep -v Tooth`. Now extend it!"),
             has_code('\|\s+sort', incorrect_msg="Have you extended the command with `| sort`?"),
-            has_code('\|\s+uniq\s+-c\s*', incorrect_msg="Have you extended the command with `| uniq -c`?")
+            has_code('\|\s+uniq', incorrect_msg="Have you extended the command with `| uniq`?"),
+            has_code('-c', incorrect_msg="Have you included counts with `-c`?")
         )
     )
 )

--- a/chapter3.md
+++ b/chapter3.md
@@ -236,6 +236,10 @@ cut -d , -f 2 seasonal/summer.csv | grep -v Tooth
 
 Extend this pipeline with a `head` command to only select the very first tooth name.
 
+*** =hint
+
+Copy and paste the code in the instructions, append a pipe, then call `head` with the `-n` flag.
+
 *** =solution
 ```{shell}
 cut -d , -f 2 seasonal/autumn.csv | grep -v Tooth | head -n 1
@@ -246,8 +250,11 @@ cut -d , -f 2 seasonal/autumn.csv | grep -v Tooth | head -n 1
 Ex().multi(
     has_cwd('/home/repl'),
     # for some reason has_expr_output with strict=True does not work here...
-    has_output('^\s*canine\s*$', incorrect_msg = "Have you used `|` to extend the pipeline with a `head` command? Make sure to set the `-n` flag correctly.")
+    has_output('^\s*canine\s*$', incorrect_msg = "Have you used `|` to extend the pipeline with a `head` command? Make sure to set the `-n` flag correctly."),
+    # by coincidence, tail -n 1 returns the same as head -n 1, so check that head was called
+    has_code("head", "Have you used `|` to extend the pipeline with a `head` command?")
 )
+Ex().success_msg("Cheerful chaining! By chaining several commands together, you can build powerful data manipulation pipelines.")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:ae6a48d6aa

--- a/chapter3.md
+++ b/chapter3.md
@@ -332,6 +332,11 @@ cut -d , -f 1 seasonal/*.csv
 Write a single command using `head` to get the first three lines from both `seasonal/spring.csv` and `seasonal/summer.csv`, a total of six lines of data, but *not* from the autumn or winter data files.
 Use a wildcard instead of spelling out the files' names in full.
 
+*** =hint
+
+- The command takes the form `head -n number_of_lines filename_pattern`.
+- You could match files in directory `a`, starting with `b`, using `a/b*`, for example.
+
 *** =solution
 ```{shell}
 head -n 3 seasonal/s* # ...or seasonal/s*.csv, or even s*/s*.csv
@@ -341,9 +346,11 @@ head -n 3 seasonal/s* # ...or seasonal/s*.csv, or even s*/s*.csv
 ```{python}
 Ex().multi(
     has_cwd('/home/repl'),
-    has_expr_output(incorrect_msg = "You can use `seasonal/s*` to select `seasonal/spring.csv` and `seasonal/summer.csv`. Make sure to only include the first three lines of each file with the `-n` flag!")
+    has_expr_output(incorrect_msg = "You can use `seasonal/s*` to select `seasonal/spring.csv` and `seasonal/summer.csv`. Make sure to only include the first three lines of each file with the `-n` flag!"),
+    check_not(has_output('==> seasonal/autumn.csv <=='), incorrect_msg = "Don't include the output for `seasonal/autumn.csv`. You can use `seasonal/s*` to select `seasonal/spring.csv` and `seasonal/summer.csv`"),
+    check_not(has_output('==> seasonal/winter.csv <=='), incorrect_msg = "Don't include the output for `seasonal/winter.csv`. You can use `seasonal/s*` to select `seasonal/spring.csv` and `seasonal/summer.csv`")
 )
-Ex().success_msg("Good work!")
+Ex().success_msg("Wild wildcard work! This becomes even more important if your directory contains hundreds or thousands of files.")
 ```
 
 --- type:PureMultipleChoiceExercise lang:bash xp:50 key:f8feeacd8c

--- a/chapter3.md
+++ b/chapter3.md
@@ -42,8 +42,11 @@ it works with every shell command that produces output.
 
 *** =instructions
 
-Save the last 5 lines of `seasonal/winter.csv` in a file called `last.csv`.
-(Use `tail -n 5` to get the last 5 lines.)
+Combine `tail` with redirection to save the last 5 lines of `seasonal/winter.csv` in a file called `last.csv`.
+
+*** =hint
+
+Use `tail -n 5` to get the last 5 lines.
 
 *** =solution
 ```{shell}
@@ -56,6 +59,7 @@ patt = "The line `%s` should be in the file `last.csv`, but it isn't. Redirect t
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/last.csv').multi(
+        check_not(has_code('2017-07-01,incisor'), incorrect_msg='`last.csv` has too many lines. Did you use the flag `-n 5` with `tail`?'),
         has_code('2017-07-17,canine', incorrect_msg=patt%'2017-07-17,canine'),
         has_code('2017-08-13,canine', incorrect_msg=patt%'2017-08-13,canine')
     )

--- a/chapter3.md
+++ b/chapter3.md
@@ -287,7 +287,7 @@ Ex().multi(
       has_code("grep", incorrect_msg = "Did you call `grep`?"),
       has_code("2017-07", incorrect_msg = "Did you search for `2017-07`?"),
       has_code("seasonal/spring.csv", incorrect_msg = "Did you search the `seasonal/spring.csv` file?"),
-      has_code("|", incorrect_msg = "Did you pipe to `wc` using `|`?"),
+      has_code("|", incorrect_msg = "Did you pipe to `wc` using `|`?"),      
       has_code("wc", incorrect_msg = "Did you call `wc`?"),
       has_code("-l", incorrect_msg = "Did you count lines with `-l`?")
     )
@@ -405,6 +405,10 @@ cut -d , -f 2 seasonal/summer.csv | grep -v Tooth
 
 Starting from this recipe, sort the names of the teeth in `seasonal/winter.csv` (not `summer.csv`) in descending alphabetical order. To do this, extend the pipeline with a `sort` step.
 
+*** =hint
+
+Copy and paste the command in the instructions, change the filename, append a pipe, then call `sort` with the `-r` flag.
+
 *** =solution
 ```{shell}
 cut -d , -f 2 seasonal/winter.csv | grep -v Tooth | sort -r
@@ -413,9 +417,23 @@ cut -d , -f 2 seasonal/winter.csv | grep -v Tooth | sort -r
 *** =sct
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    has_expr_output(incorrect_msg = "Have you used `|` to extend the pipeline with a `sort` command? Make sure to work with `seasonal/winter.csv` and to sort in descending alphabetical order with the appropriate flag.")
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(strict=True),
+    multi(
+      has_code("cut", incorrect_msg = "Did you call `cut`?"),
+      has_code("-d", incorrect_msg = "Did you specify a field delimiter with `-d`?"),
+      has_code("seasonal/winter.csv", incorrect_msg = "Did you get data from the `seasonal/winter.csv` file?"),
+      has_code("|", incorrect_msg = "Did you pipe from `cut` to `grep` to `sort` using `|`?"),      
+      has_code("grep", incorrect_msg = "Did you call `grep`?"),
+      has_code("-v", incorrect_msg = "Did you invert the match with `-v`?"),
+      has_code("Tooth", incorrect_msg = "Did you search for `Tooth`?"),
+      has_code("sort", incorrect_msg = "Did you call `sort`?"),
+      has_code("-r", incorrect_msg = "Did you reverse the sort order with `-r`?")
+    )
+  )
 )
+Ex().success_msg("Sorted! `sort` has many uses. For example, piping `sort -n` to `head` shows you the largest values.")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:ed77aed337

--- a/chapter3.md
+++ b/chapter3.md
@@ -640,8 +640,15 @@ wc -l seasonal/*.csv
 *** =sct1
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    has_expr_output(incorrect_msg = "Have you used `wc` on `seasonal/*csv`? Make sure to include a flag that tells `wc` to count the lines.")
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(strict=True),
+    multi(
+      has_code("wc", incorrect_msg = "Did you call `wc`?"),
+      has_code("-l", incorrect_msg = "Did you count the number of lines with `-l`?"),
+      has_code("seasonal/\*", incorrect_msg = "Did you get data from all `seasonal/*` files?")
+    )
+  )
 )
 ```
 
@@ -656,7 +663,7 @@ Add another command to the previous one using a pipe to remove the line containi
 
 *** =hint3
 
-Use `grep -v total` to select lines that *don't* contain the word "total".
+Use `grep` with the `-v` flag, seraching for `total` to select lines that *don't* contain the word "total".
 
 *** =sample_code2
 ```{shell}
@@ -669,13 +676,20 @@ wc -l seasonal/*.csv | grep -v total
 
 *** =sct2
 ```{python}
-msg="Have you piped the result of `wc -l seasonal/*.csv` into a `grep` command with `|`? Make sure to use the flag `-v` to select lines that *don't* contain `total`."
 Ex().multi(
-    has_cwd('/home/repl'),
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(strict=True),
     multi(
-        has_expr_output(incorrect_msg=msg),
-        check_not(has_output('total'), incorrect_msg=msg)
+      has_code("wc", incorrect_msg = "Did you call `wc`?"),
+      has_code("-l", incorrect_msg = "Did you count the number of lines with `-l`?"),
+      has_code("seasonal/\*", incorrect_msg = "Did you get data from all `seasonal/*` files?"),
+      has_code("|", incorrect_msg = "Did you pipe from `wc` to `grep` using `|`?"),      
+      has_code("grep", incorrect_msg = "Did you call `grep`?"),
+      has_code("-v", incorrect_msg = "Did you invert the match with `-v`?"),
+      has_code("total", incorrect_msg = "Did you search for `total`?")
     )
+  )
 )
 ```
 
@@ -690,7 +704,8 @@ Add two more stages to the pipeline that use `sort -n` and `head -n 1` to find t
 
 *** =hint3
 
-Remember to use `sort -n` to sort numerically.
+- Use `sort`'s `-n` flag to sort numerically.
+- Use `head`'s `-n` flag to limit to keeping 1 line. 
 
 *** =sample_code3
 ```{shell}
@@ -703,10 +718,23 @@ wc -l seasonal/*.csv | grep -v total | sort -n | head -n 1
 
 *** =sct3
 ```{python}
-msg = "Pipe the result of `wc -l seasonal/*.csv | grep -v total` to `sort -n`, which you then pipe into `head -n 1` to make the appropriate printout."
 Ex().multi(
-    has_cwd('/home/repl'),
-    has_expr_output(strict=True, incorrect_msg=msg)
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(strict=True),
+    multi(
+      has_code("wc", incorrect_msg = "Did you call `wc`?"),
+      has_code("-l", incorrect_msg = "Did you count the number of lines with `-l`?"),
+      has_code("seasonal/\*", incorrect_msg = "Did you get data from all `seasonal/*` files?"),
+      has_code("|", incorrect_msg = "Did you pipe from `wc` to `grep` to `sort` to `head` using `|`?"),      
+      has_code("grep", incorrect_msg = "Did you call `grep`?"),
+      has_code("-v", incorrect_msg = "Did you invert the match with `-v`?"),
+      has_code("total", incorrect_msg = "Did you search for `total`?"),
+      has_code("sort", incorrect_msg = "Did you call `sort`?"),
+      has_code("-n", incorrect_msg = "Did you specify the number of lines to keep with `-n`?"),
+      has_code("1", incorrect_msg = "Did you specify 1 line to keep with `-n 1`?")
+    )
+  )
 )
 Ex().success_msg("Great! It turns out `autumn.csv` is the file with the fewest lines. Rush over to chapter 4 to learn more about batch processing!")
 ```

--- a/chapter3.md
+++ b/chapter3.md
@@ -187,8 +187,12 @@ as the input to the command on the right.
 
 *** =instructions
 
-Write a pipeline that uses `cut` to select all of the tooth names from column 2 of `seasonal/summer.csv`
-and then `grep -v` to exclude the header line containing the word "Tooth".
+Use `cut` to select all of the tooth names from column 2 of the comma delimited file `seasonal/summer.csv`, then pipe the result to `grep`, with an inverted match, to exclude the header line containing the word "Tooth". *`cut` and `grep` were covered in detail in Chapter 2, exercises 8 and 11 respectively.*
+
+*** =hint
+
+- The first part of the command takes the form `cut -d field_delimiter -f column_number filename`.
+- The second part of the command takes the form `grep -v thing_to_match`.
 
 *** =solution
 ```{shell}
@@ -199,9 +203,10 @@ cut -d , -f 2 seasonal/summer.csv | grep -v Tooth
 ```{python}
 Ex().multi(
     has_cwd('/home/repl'),
-    has_expr_output(incorrect_msg = 'Have you piped the result of `cut -d , -f 2 seasonal/summer.csv` into `grep -v Tooth` with `|`?')
+    has_expr_output(incorrect_msg = 'Have you piped the result of `cut -d , -f 2 seasonal/summer.csv` into `grep -v Tooth` with `|`?'),
+    check_not(has_output("Tooth"), incorrect_msg = 'Did you exclude the `"Tooth"` header line using `grep`?')
 )
-Ex().success_msg("This may be the first time you used `|`, but it's definitely not the last!")
+Ex().success_msg("Perfect piping! This may be the first time you used `|`, but it's definitely not the last!")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:b8753881d6

--- a/chapter3.md
+++ b/chapter3.md
@@ -266,6 +266,12 @@ You can make it print only one of these using `-c`, `-w`, or `-l` respectively.
 *** =instructions
 Count how many records in `seasonal/spring.csv` have dates in July 2017. To do this, use `grep` with a partial date to select the lines and pipe this result into `wc` with an appropriate flag to count the lines.
 
+*** =hint
+
+- Use `head seasonal/spring.csv` to remind yourself of the date format.
+- The first part of the command tkaes the form `grep thing_to_match filename`.
+- After the pipe, `|`, call `wc` with the `-l` flag.
+
 *** =solution
 ```{shell}
 grep 2017-07 seasonal/spring.csv | wc -l
@@ -273,11 +279,21 @@ grep 2017-07 seasonal/spring.csv | wc -l
 
 *** =sct
 ```{python}
-msg="Pipe the result of `grep 2017-07 seasonal/spring.csv` into `wc`. Make sure to use the appropriate flag; you want to count the number of _lines_."
 Ex().multi(
-    has_cwd('/home/repl'),
-    has_expr_output(strict=True, incorrect_msg=msg)
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(strict=True),
+    multi(
+      has_code("grep", incorrect_msg = "Did you call `grep`?"),
+      has_code("2017-07", incorrect_msg = "Did you search for `2017-07`?"),
+      has_code("seasonal/spring.csv", incorrect_msg = "Did you search the `seasonal/spring.csv` file?"),
+      has_code("|", incorrect_msg = "Did you pipe to `wc` using `|`?"),
+      has_code("wc", incorrect_msg = "Did you call `wc`?"),
+      has_code("-l", incorrect_msg = "Did you count lines with `-l`?")
+    )
+  )
 )
+Ex().success_msg("Careful counting! Determining how much data you have is a great first step in any data analysis.")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:602d47e70c

--- a/chapter3.md
+++ b/chapter3.md
@@ -118,6 +118,7 @@ patt="The line `%s` should be in the file `bottom.csv`, but it isn't. Redirect t
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/bottom.csv').multi(
+        check_not(has_code('2017-08-11,bicuspid'), incorrect_msg = '`bottom.csv` has too many lines. Did you use the flag `-n 2` with `tail`?'),
         has_code('2017-08-11,wisdom', incorrect_msg=patt%"2017-08-11,wisdom"),
         has_code('2017-08-13,canine', incorrect_msg=patt%"2017-08-13,canine")
     )

--- a/chapter3.md
+++ b/chapter3.md
@@ -590,11 +590,13 @@ head
 with no arguments (so that it waits for input that will never come)
 and then stop it by typing <kbd>Ctrl</kbd> + <kbd>C</kbd>.
 
+*** =hint
+
+Simply type head, hit Enter and exit the running program with Ctrl + C.
+
 *** =solution
-```{bash}
-# This solution is different from what you should do.
+```{shell}
 # Simply type head, hit Enter and exit the running program with Ctrl + C.
-echo 'head'
 ```
 
 *** =sct

--- a/chapter4.md
+++ b/chapter4.md
@@ -51,7 +51,7 @@ err1 = "No: the shell records more history than that."
 err2 = "No: the shell records more history than that."
 correct3 = "Correct: the shell saves 2000 old commands by default on this system."
 err4 = "No: the variable `HISTFILESIZE` is there."
-Ex() >> test_mc(3, [err1, err2, correct3, err4])
+Ex().has_chosen(3, [err1, err2, correct3, err4])
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:afae0f33a7
@@ -105,9 +105,18 @@ echo $OSTYPE
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['echo', '', re.compile(r'\$OSTYPE')]],
-                     msg='Remember to put `$` in front of the variable name')
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_correct(
+        has_expr_output(),
+        multi(
+            has_code('echo', incorrect_msg="You should use `echo` in your command."),
+            has_code('OSTYPE', incorrect_msg="You should use `OSTYPE` in your command."),
+            has_code('$', incorrect_msg="Make sure to prepend `OSTYPE` by a `$`")
+        )
+    )
+)
+Ex().success_msg("You're off to a good start. Let's carry on!")
 ```
 
 --- type:BulletConsoleExercise key:e925da48e4
@@ -162,9 +171,21 @@ testing=seasonal/winter.csv
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*testing=seasonal/winter\.csv\s*',
-                           fixed=False,
-                           msg='Set `testing` with `variable=value`.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_correct(
+        has_expr_output(
+            expr='echo $testing',
+            output='seasonal/winter.csv',
+            incorrect_msg="Have you used `testing=seasonal/winter.csv` to define the `testing` variable?"
+        ),
+        multi(
+            has_code("testing", incorrect_msg="You should use `testing` in your command."),
+            has_code("=", incorrect_msg="You should use the `=` sign in your command."),
+            has_code("seasonal/winter\.csv", incorrect_msg="You should use `seasonal/winter.csv` in your command.")
+        )
+    )
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -190,18 +211,26 @@ Remember to use `$testing` rather than just `testing`
 
 *** =solution2
 ```{shell}
-# We need to re-set the variable for testing purposes for this exercise - you should only run "head -n 1 $testing"
+# We need to re-set the variable for testing purposes for this exercise
+# you should only run "head -n 1 $testing"
 testing=seasonal/winter.csv
 head -n 1 $testing
 ```
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['head', 'n:', re.compile(r'\$testing'), {'-n' : '1'}]],
-                     last_line=True,
-                     msg='Did you use `head` with `$testing` as an argument?') \
-     >> test_expr('head -n 1 seasonal/winter.csv', msg = 'Did you use `head` with `$testing` as an argument?')
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_correct(
+        has_output('^Date,Tooth\s*$', incorrect_msg="Have you used `head -n 1 $testing`?"),
+        multi(
+            has_code('head', incorrect_msg="You should use `head` in your command."),
+            has_code('-n\s+1', incorrect_msg="You should use `-n 1` in your command."),
+            has_code('\$testing', incorrect_msg="you should use `$testing` in your command.")
+        )
+    )
+)
+Ex().success_msg("Stellar! Let's see how you can repeat commands easily.")
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:920d1887e3
@@ -255,9 +284,14 @@ for suffix in docx odt pdf; do echo $suffix; done
 
 *** =sct
 ```{python}
-Ex() >> test_student_typed(r'\s*for\s+suffix\s+in\s+docx\s+odt\s+pdf\s*;\s*do\s+echo\s+\$suffix\s*;\s*done\s*',
-                           fixed=False,
-                           msg='Change the list of suffix names that the loop operatores on.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*for\s+suffix\s+in\s+docx\s+odt\s+pdf\s*;\s*do\s+echo\s+\$suffix\s*;\s*done\s*',
+                 incorrect_msg='Change the list of suffix names that the loop operatores on: `docx odt pdf` instead of `gif jpg png`.')
+    )
+)
 ```
 
 --- type:ConsoleExercise xp:100 key:8468b70a71
@@ -297,9 +331,14 @@ for filename in people/*; do echo $filename; done
 
 *** =sct
 ```{python}
-Ex() >> test_student_typed(r'\s*for\s+filename\s+in\s+([~.]/)?people/\*\s*;\s*do\s+echo\s+\$filename\s*;\s*done\s*',
-                           fixed=False,
-                           msg='Use `people/*` to get the name of all the files in the `people` directory.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*for\s+filename\s+in\s+([~.]/)?people/\*\s*;\s*do\s+echo\s+\$filename\s*;\s*done\s*',
+                 incorrect_msg='The example uses `seasonal/*.csv`; you should use `people/*` to get the name of all the files in the `people` directory.')
+    )
+)
 ```
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:153ca10317
@@ -349,7 +388,7 @@ Remember that `X` on its own is just "X", while `$X` is the value of the variabl
 err1 = "No: you do not have to define a variable on the same line you use it."
 err2 = "No: this example defines and uses the variable `files` in the same shell."
 correct3 = "Correct."
-Ex() >> test_mc(3, [err1, err2, correct3])
+Ex().has_chosen(3, [err1, err2, correct3])
 ```
 
 --- type:PureMultipleChoiceExercise lang:bash xp:50 key:4fcfb63c4f
@@ -398,7 +437,7 @@ for f in files; do echo $f; done
 
 Remember that `X` on its own is just "X", while `$X` is the value of the variable `X`.
 
-*** =feedbacks
+*** =feedback
 - Correct: the loop uses `files` instead of `$files`, so the list consists of the word "files".
 - No: the loop uses `files` instead of `$files`, so the list consists of the word "files" rather than the expansion of `files`.
 - No: the variable `f` is defined automatically by the `for` loop.
@@ -436,9 +475,13 @@ for file in seasonal/*.csv; do grep 2017-07 $file; done
 
 *** =sct
 ```{python}
-Ex() >> test_student_typed(r'\s*for\s+file\s+in\s+seasonal/\*\.csv\s*;\s*do\s+grep(\s+-h)?\s+2017-07\s+\$file\s*;\s*done\s*',
-                           fixed=False,
-                           msg='Use `grep 2017-07 $file` as the body of the loop.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*for\s+file\s+in\s+seasonal/\*\.csv\s*;\s*do\s+grep(\s+-h)?\s+2017-07\s+\$file\s*;\s*done\s*', incorrect_msg='Use `grep 2017-07 $file` as the body of the loop.')
+    )
+)
 ```
 
 --- type:PureMultipleChoiceExercise lang:bash xp:50 key:b974b7f45a
@@ -489,7 +532,7 @@ what will happen:
 
 What would you think was going to happen if someone showed you the command and you didn't know what files existed?
 
-*** =feedbacks
+*** =feedback
 - Yes, but that's not all.
 - Yes, but that's not all.
 - Correct.
@@ -506,6 +549,7 @@ you must separate them with semi-colons:
 ```{shell}
 for f in seasonal/*.csv; do echo $f; head -n 2 $f | tail -n 1; done
 ```
+
 ```
 seasonal/autumn.csv
 2017-01-05,canine
@@ -548,5 +592,5 @@ err1 = "No: the loop will run, it just won't do something sensible."
 correct2 = "Yes: `echo` produces one line that includes the filename twice, which `tail` then copies."
 err3 = "No: the loop runs one for each of the four filenames."
 err4 = "No: the input of `tail` is the output of `echo` for each filename."
-Ex() >> test_mc(2, [err1, correct2, err3, err4])
+Ex().has_chosen(2, [err1, correct2, err3, err4])
 ```

--- a/chapter4.md
+++ b/chapter4.md
@@ -504,6 +504,10 @@ but uses a loop to process each file separately.
 Please use `file` as the name of the loop variable,
 and remember that the `-h` flag used above tells `grep` *not* to print filenames in the output.
 
+*** =hint
+
+The loop body is the grep command shown in the instructions, with `seasonal/*.csv` replaced by `$file`.
+
 *** =solution
 ```{bash}
 for file in seasonal/*.csv; do grep 2017-07 $file; done
@@ -512,12 +516,26 @@ for file in seasonal/*.csv; do grep 2017-07 $file; done
 *** =sct
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    check_correct(
-        has_expr_output(),
-        has_code(r'\s*for\s+file\s+in\s+seasonal/\*\.csv\s*;\s*do\s+grep(\s+-h)?\s+2017-07\s+\$file\s*;\s*done\s*', incorrect_msg='Use `grep 2017-07 $file` as the body of the loop.')
+  has_cwd('/home/repl'),
+  # Enforce use of for loop, so students can't just use grep -h 2017-07 seasonal/*.csv
+  has_code('for', incorrect_msg='Did you call `for`?'),
+  check_correct(
+    has_expr_output(),
+    multi(
+      has_code('2017-07', incorrect_msg='Did you match on `2017-07`?'), # This needs to be higher precedence than choice of loop variable
+      has_code('file', incorrect_msg='Did you use `file` as the loop variable?'),
+      has_code('in', incorrect_msg='Did you use `in` before the list of files?'),
+      has_code('seasonal/\*', incorrect_msg='Did you specify a list of files with `seasonal/*`?'),
+      has_code(r'seasonal/[*.csv]*\s*;', incorrect_msg='Did you put a semi-colon after the list of files?'),
+      has_code(r';\s*do', incorrect_msg='Did you use `do` after the first semi-colon?'),
+      has_code('grep', incorrect_msg='Did you call `grep`?'),
+      has_code('$file', incorrect_msg='Did you echo `$file`?'),
+      has_code(r'file\s*;', incorrect_msg='Did you put a semi-colon after the loop body?'),
+      has_code('; done', incorrect_msg='Did you finish with `done`?')
     )
+  )
 )
+Ex().success_msg("Loopy looping! Wildcards and loops make a powerful combination.")
 ```
 
 --- type:PureMultipleChoiceExercise lang:bash xp:50 key:b974b7f45a

--- a/chapter4.md
+++ b/chapter4.md
@@ -589,7 +589,7 @@ What would you think was going to happen if someone showed you the command and y
 *** =feedback
 - Yes, but that's not all.
 - Yes, but that's not all.
-- Correct.
+- Correct. You can use single quotes, `'`, or double quotes, `"`, around the file names.
 - Unfortunately not.
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:f6d0530991

--- a/chapter4.md
+++ b/chapter4.md
@@ -250,7 +250,7 @@ which repeat commands many times.
 If we run this command:
 
 ```{shell}
-for suffix in gif jpg png; do echo $suffix; done
+for filetype in gif jpg png; do echo $filetype; done
 ```
 
 it produces:
@@ -261,14 +261,14 @@ jpg
 png
 ```
 
-The loop's parts are:
+Notice these things about the loop:
 
-1. The skeleton `for` ...variable... `in` ...list... `; do` ...body... `; done`
+1. The structure is `for` ...variable... `in` ...list... `; do` ...body... `; done`
 2. The list of things the loop is to process (in our case, the words `gif`, `jpg`, and `png`).
-3. The variable that keeps track of which thing the loop is currently processing (in our case, `suffix`).
-4. The body of the loop that does the processing (in our case, `echo $suffix`).
+3. The variable that keeps track of which thing the loop is currently processing (in our case, `filetype`).
+4. The body of the loop that does the processing (in our case, `echo $filetype`).
 
-Notice that the body uses `$suffix` to get the variable's value instead of just `suffix`,
+Notice that the body uses `$filetype` to get the variable's value instead of just `filetype`,
 just like it does with any other shell variable.
 Also notice where the semi-colons go:
 the first one comes between the list and the keyword `do`,
@@ -284,23 +284,38 @@ odt
 pdf
 ```
 
-Please use `suffix` as the name of the loop variable.
+Please use `filetype` as the name of the loop variable.
+
+*** =hint
+
+Use the code structure in the introductory text, swapping the image file types for document file types.
 
 *** =solution
 ```{shell}
-for suffix in docx odt pdf; do echo $suffix; done
+for filetype in docx odt pdf; do echo $filetype; done
 ```
 
 *** =sct
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    check_correct(
-        has_expr_output(),
-        has_code(r'\s*for\s+suffix\s+in\s+docx\s+odt\s+pdf\s*;\s*do\s+echo\s+\$suffix\s*;\s*done\s*',
-                 incorrect_msg='Change the list of suffix names that the loop operatores on: `docx odt pdf` instead of `gif jpg png`.')
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(),
+    multi(
+      has_code('for', incorrect_msg='Did you call `for`?'),
+      has_code('filetype', incorrect_msg='Did you use `filetype` as the loop variable?'),
+      has_code('in', incorrect_msg='Did you use `in` before the list of file types?'),
+      has_code('docx odt pdf', incorrect_msg='Did you loop over `docx`, `odt` and `pdf` in that order?'),
+      has_code('pdf;', incorrect_msg='Did you put a semi-colon after the last loop element?'),
+      has_code(r';\s*do', incorrect_msg='Did you use `do` after the first semi-colon?'),
+      has_code('echo', incorrect_msg='Did you call `echo`?'),
+      has_code('$filetype', incorrect_msg='Did you echo `$filetype`?'),
+      has_code(r'filetype\s*;', incorrect_msg='Did you put a semi-colon after the loop body?'),
+      has_code('; done', incorrect_msg='Did you finish with `done`?')
     )
+  )
 )
+Ex().success_msg("First-rate for looping! Loops are brilliant if you want to do the same thing hundreds or thousands of times.")
 ```
 
 --- type:ConsoleExercise xp:100 key:8468b70a71

--- a/chapter4.md
+++ b/chapter4.md
@@ -306,7 +306,7 @@ Ex().multi(
       has_code('filetype', incorrect_msg='Did you use `filetype` as the loop variable?'),
       has_code('in', incorrect_msg='Did you use `in` before the list of file types?'),
       has_code('docx odt pdf', incorrect_msg='Did you loop over `docx`, `odt` and `pdf` in that order?'),
-      has_code('pdf;', incorrect_msg='Did you put a semi-colon after the last loop element?'),
+      has_code(r'pdf\s*;', incorrect_msg='Did you put a semi-colon after the last loop element?'),
       has_code(r';\s*do', incorrect_msg='Did you use `do` after the first semi-colon?'),
       has_code('echo', incorrect_msg='Did you call `echo`?'),
       has_code('$filetype', incorrect_msg='Did you echo `$filetype`?'),
@@ -348,6 +348,7 @@ so that the loop prints the names of the files in the `people` directory
 regardless of what suffix they do or don't have.
 Please use `filename` as the name of your loop variable.
 
+
 *** =solution
 ```{bash}
 for filename in people/*; do echo $filename; done
@@ -356,13 +357,24 @@ for filename in people/*; do echo $filename; done
 *** =sct
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    check_correct(
-        has_expr_output(),
-        has_code(r'\s*for\s+filename\s+in\s+([~.]/)?people/\*\s*;\s*do\s+echo\s+\$filename\s*;\s*done\s*',
-                 incorrect_msg='The example uses `seasonal/*.csv`; you should use `people/*` to get the name of all the files in the `people` directory.')
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(),
+    multi(
+      has_code('for', incorrect_msg='Did you call `for`?'),
+      has_code('filename', incorrect_msg='Did you use `filename` as the loop variable?'),
+      has_code('in', incorrect_msg='Did you use `in` before the list of file types?'),
+      has_code('people/\*', incorrect_msg='Did you specify a list of files with `people/*`?'),
+      has_code(r'people/\*\s*;', incorrect_msg='Did you put a semi-colon after the list of files?'),
+      has_code(r';\s*do', incorrect_msg='Did you use `do` after the first semi-colon?'),
+      has_code('echo', incorrect_msg='Did you call `echo`?'),
+      has_code('$filename', incorrect_msg='Did you echo `$filename`?'),
+      has_code(r'filename\s*;', incorrect_msg='Did you put a semi-colon after the loop body?'),
+      has_code('; done', incorrect_msg='Did you finish with `done`?')
     )
+  )
 )
+Ex().success_msg("Loopy looping! Wildcards and loops make a powerful combination.")
 ```
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:153ca10317

--- a/chapter4.md
+++ b/chapter4.md
@@ -177,19 +177,21 @@ testing=seasonal/winter.csv
 
 *** =sct1
 ```{python}
+# For some reason, testing the shell variable directly always passes, so we can't do the following.
+# Ex().multi(
+#     has_cwd('/home/repl'),
+#     has_expr_output(
+#         expr='echo $testing',
+#         output='seasonal/winter.csv',
+#         incorrect_msg="Have you used `testing=seasonal/winter.csv` to define the `testing` variable?"
+#     )
+# )
 Ex().multi(
     has_cwd('/home/repl'),
-    check_correct(
-        has_expr_output(
-            expr='echo $testing',
-            output='seasonal/winter.csv',
-            incorrect_msg="Have you used `testing=seasonal/winter.csv` to define the `testing` variable?"
-        ),
-        multi(
-            has_code(r'testing', incorrect_msg='You should use `testing` in your command.'),
-            has_code(r'=', incorrect_msg='You should use the `=` sign in your command.'),
-            has_code(r'seasonal/winter\.csv', incorrect_msg='You should use `seasonal/winter.csv` in your command.')
-        )
+    multi(
+        has_code('testing', incorrect_msg='Did you define a shell variable named `testing`?'),
+        has_code('testing=', incorrect_msg='Did you write `=` directly after testing, with no spaces?'),
+        has_code('=seasonal/winter\.csv', incorrect_msg='Did you set the value of `testing` to `seasonal/winter.csv`?')
     )
 )
 ```
@@ -227,12 +229,13 @@ head -n 1 $testing
 ```{python}
 Ex().multi(
     has_cwd('/home/repl'),
+    has_code(r'\$testing', incorrect_msg="Did you reference the shell variable using `$testing`?"),
     check_correct(
-        has_output('^Date,Tooth\s*$', incorrect_msg="Have you used `head -n 1 $testing`?"),
+        has_output('^Date,Tooth\s*$'),
         multi(
-            has_code(r'head', incorrect_msg="You should use `head` in your command."),
-            has_code(r'-n\s+1', incorrect_msg="You should use `-n 1` in your command."),
-            has_code(r'\$testing', incorrect_msg="you should use `$testing` in your command.")
+            has_code('head', incorrect_msg="Did you call `head`?"),
+            has_code('-n', incorrect_msg="Did you limit the number of lines with `-n`?"),
+            has_code(r'-n\s+1', incorrect_msg="Did you elect to keep 1 line with `-n 1`?")     
         )
     )
 )

--- a/chapter4.md
+++ b/chapter4.md
@@ -110,9 +110,9 @@ Ex().multi(
     check_correct(
         has_expr_output(),
         multi(
-            has_code('echo', incorrect_msg="You should use `echo` in your command."),
-            has_code('OSTYPE', incorrect_msg="You should use `OSTYPE` in your command."),
-            has_code('$', incorrect_msg="Make sure to prepend `OSTYPE` by a `$`")
+            has_code(r'echo', incorrect_msg="You should use `echo` in your command."),
+            has_code(r'OSTYPE', incorrect_msg="You should use `OSTYPE` in your command."),
+            has_code(r'$', incorrect_msg="Make sure to prepend `OSTYPE` by a `$`")
         )
     )
 )
@@ -180,9 +180,9 @@ Ex().multi(
             incorrect_msg="Have you used `testing=seasonal/winter.csv` to define the `testing` variable?"
         ),
         multi(
-            has_code("testing", incorrect_msg="You should use `testing` in your command."),
-            has_code("=", incorrect_msg="You should use the `=` sign in your command."),
-            has_code("seasonal/winter\.csv", incorrect_msg="You should use `seasonal/winter.csv` in your command.")
+            has_code(r'testing', incorrect_msg='You should use `testing` in your command.'),
+            has_code(r'=', incorrect_msg='You should use the `=` sign in your command.'),
+            has_code(r'seasonal/winter\.csv', incorrect_msg='You should use `seasonal/winter.csv` in your command.')
         )
     )
 )
@@ -224,9 +224,9 @@ Ex().multi(
     check_correct(
         has_output('^Date,Tooth\s*$', incorrect_msg="Have you used `head -n 1 $testing`?"),
         multi(
-            has_code('head', incorrect_msg="You should use `head` in your command."),
-            has_code('-n\s+1', incorrect_msg="You should use `-n 1` in your command."),
-            has_code('\$testing', incorrect_msg="you should use `$testing` in your command.")
+            has_code(r'head', incorrect_msg="You should use `head` in your command."),
+            has_code(r'-n\s+1', incorrect_msg="You should use `-n 1` in your command."),
+            has_code(r'\$testing', incorrect_msg="you should use `$testing` in your command.")
         )
     )
 )

--- a/chapter4.md
+++ b/chapter4.md
@@ -392,7 +392,7 @@ Ex().has_chosen(3, [err1, err2, correct3])
 ```
 
 --- type:PureMultipleChoiceExercise lang:bash xp:50 key:4fcfb63c4f
-## What's the difference between a variable's name and its value?
+## A variable's name versus its value
 
 A common mistake is to forget to use `$` before the name of a variable.
 When you do this,

--- a/chapter4.md
+++ b/chapter4.md
@@ -57,12 +57,14 @@ Ex().has_chosen(3, [err1, err2, correct3, err4])
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:afae0f33a7
 ## How can I print a variable's value?
 
-A simpler way to find a variable's value is to use a command called `echo`,
-which prints its arguments:
+A simpler way to find a variable's value is to use a command called `echo`, which prints its arguments. Typing
 
 ```{shell}
 echo hello DataCamp!
 ```
+
+prints
+
 ```
 hello DataCamp!
 ```
@@ -72,17 +74,17 @@ If you try to use it to print a variable's value like this:
 ```{shell}
 echo USER
 ```
-```
-USER
-```
 
-it will print the variable's name.
-To get the variable's value,
-you must put a dollar sign `$` in front of it:
+it will print the variable's name, `USER`.
+
+To get the variable's value, you must put a dollar sign `$` in front of it. Typing 
 
 ```{shell}
 echo $USER
 ```
+
+prints
+
 ```
 repl
 ```
@@ -98,6 +100,10 @@ or "the value of a variable named X".)
 The variable `OSTYPE` holds the name of the kind of operating system you are using.
 Display its value using `echo`.
 
+*** =hint
+
+Call `echo` with the variable `OSTYPE` prepended by `$`.
+
 *** =solution
 ```{shell}
 echo $OSTYPE
@@ -110,13 +116,13 @@ Ex().multi(
     check_correct(
         has_expr_output(),
         multi(
-            has_code(r'echo', incorrect_msg="You should use `echo` in your command."),
-            has_code(r'OSTYPE', incorrect_msg="You should use `OSTYPE` in your command."),
-            has_code(r'$', incorrect_msg="Make sure to prepend `OSTYPE` by a `$`")
+            has_code('echo', incorrect_msg="Did you call `echo`?"),
+            has_code('OSTYPE', incorrect_msg="Did you print the `OSTYPE` environment variable?"),
+            has_code('$OSTYPE', incorrect_msg="Make sure to prepend `OSTYPE` by a `$`.")
         )
     )
 )
-Ex().success_msg("You're off to a good start. Let's carry on!")
+Ex().success_msg("Excellent echoing of environment variables! You're off to a good start. Let's carry on!")
 ```
 
 --- type:BulletConsoleExercise key:e925da48e4

--- a/chapter4.md
+++ b/chapter4.md
@@ -423,7 +423,7 @@ Remember that `X` on its own is just "X", while `$X` is the value of the variabl
 ```{python}
 err1 = "No: you do not have to define a variable on the same line you use it."
 err2 = "No: this example defines and uses the variable `files` in the same shell."
-correct3 = "Correct."
+correct3 = "Correct. The command is equivalent to `for f in seasonal/*.csv; do echo $f; done`."
 Ex().has_chosen(3, [err1, err2, correct3])
 ```
 

--- a/chapter5.md
+++ b/chapter5.md
@@ -956,6 +956,6 @@ What does `head` do if it doesn't have a filename and nothing is upstream from i
 ```{python}
 a1 = 'No, commands will not time out.'
 a2 = 'No, that will give `head` the text `somefile.txt` to process, but then it will hang up waiting for still more input.'
-a3 = 'Yes! You should use Ctrl-C to stop a running program. This concludes this introductory course! If you're interested to learn more command line tools, we thoroughly recommend taking our intro to Git course!'
+a3 = "Yes! You should use Ctrl-C to stop a running program. This concludes this introductory course! If you're interested to learn more command line tools, we thoroughly recommend taking our free intro to Git course!"
 Ex().has_chosen(3, [a1, a2, a3])
 ```

--- a/chapter5.md
+++ b/chapter5.md
@@ -415,7 +415,7 @@ Ex().multi(
     multi(
       has_code("bash", incorrect_msg = 'Did you call `bash`?'),
       has_code("bash\s+teeth.sh", incorrect_msg = 'Did you run the `teeth.sh` file?'),
-      has_code(">\s+teeth.sh", incorrect_msg = 'Did you redirect to the `teeth.out` file?')
+      has_code(">\s+teeth.out", incorrect_msg = 'Did you redirect to the `teeth.out` file?')
     )
   )
 )
@@ -557,10 +557,17 @@ bash count-records.sh seasonal/*.csv > num-records.out
 
 *** =sct2
 ```{python}
-msg="Have you correctly redirected the result of `bash count-records.sh seasonal/*.csv` to `num-records.out` with the `>`?"
 Ex().multi(
-    has_cwd('/home/repl'),
-    check_file('/home/repl/num-records.out').has_code(r'92', incorrect_msg=msg)
+  has_cwd('/home/repl'),
+  check_correct(
+    check_file('/home/repl/num-records.out').has_code(r'92'),
+    multi(
+      has_code("bash", incorrect_msg = 'Did you call `bash`?'),
+      has_code("bash\s+count-records.sh", incorrect_msg = 'Did you run the `count-records.sh` file?'),
+      has_code("seasonal/*", incorrect_msg = 'Did you specify the files to process with `seasonal/*`?'),
+      has_code(">\s+num-records.out", incorrect_msg = 'Did you redirect to the `num-records.out` file?')
+    )
+  )
 )
 Ex().success_msg("A job well done! Your shell power is ever-expanding!")
 ```

--- a/chapter5.md
+++ b/chapter5.md
@@ -298,8 +298,14 @@ bash dates.sh
 *** =sct2
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    has_expr_output(incorrect_msg="Have you used `bash dates.sh` to execute the file?")
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(incorrect_msg="Have you used `bash dates.sh` to execute the file?"),
+    multi(
+      has_code("bash", incorrect_msg = 'Did you call `bash`?'),
+      has_code("dates.sh", incorrect_msg = 'Did you specify the `dates.sh` file?')
+    )
+  )
 )
 ```
 

--- a/chapter5.md
+++ b/chapter5.md
@@ -41,20 +41,26 @@ type Ctrl-O to write the file out,
 then Enter to confirm the filename,
 then Ctrl-X and Enter to exit the editor.
 
-Note: if you view our solution,
-it uses `cp` instead of `nano` for our automated back end to check,
-because the back end can't edit files interactively.
-
 *** =solution
 ```{shell}
-# Run "nano names.txt" instead of the following command: 
-cp /solutions/names.txt .
+# This solution uses `cp` instead of `nano`
+# because our automated tests can't edit files interactively.
+cp /solutions/names.txt /home/repl
 ```
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_compare_file_to_file
-Ex() >> test_compare_file_to_file('names.txt', '/solutions/names.txt')
+patt = "Have you included the line `%s` in the `names.txt` file? Use `nano names.txt` again to update your file. Use Ctrl-O to save and Ctrl-X to exit."
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/names.txt').multi(
+        has_code('Lovelace', incorrect_msg=patt%'Lovelace'),
+        has_code('Hopper', incorrect_msg=patt%'Hopper'),
+        has_code('Johnson', incorrect_msg=patt%'Johnson'),
+        has_code('Wilson', incorrect_msg=patt%'Wilson')
+    )
+)
+Ex().success_msg("Well done! Off to the next one!")
 ```
 
 --- type:BulletConsoleExercise key:80c3532985
@@ -103,9 +109,14 @@ cp seasonal/s*.csv ~
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_compare_file_to_file
-Ex() >> test_compare_file_to_file('spring.csv', 'seasonal/spring.csv') \
-     >> test_compare_file_to_file('summer.csv', 'seasonal/summer.csv')
+msg="Have you used `cp seasonal/s*.csv ~` to copy the required files to your home directory?"
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/spring.csv', missing_msg=msg).\
+        has_code('2017-01-25,wisdom', incorrect_msg=msg),
+    check_file('/home/repl/summer.csv', missing_msg=msg).\
+        has_code('2017-01-11,canine', incorrect_msg=msg)
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -135,10 +146,16 @@ grep -h -v Tooth spring.csv summer.csv > temp.csv
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['grep', 'hv', ['Tooth', 'spring.csv', 'summer.csv']]],
-                     redirect='temp.csv',
-                     msg='Use `-h` and `-v Tooth` with `spring.csv` and `summer.csv`.')
+msg1 = "Make sure you redirect the output of the `grep` command to `temp.csv` with `>`!"
+msg2 = "Have you used `grep -h -v ___ ___ ___` (fill in the blanks) to populate `temp.csv`?"
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/temp.csv', missing_msg=msg1).multi(
+        has_code('2017-08-04,canine', incorrect_msg=msg2),
+        has_code('2017-03-14,incisor', incorrect_msg=msg2),
+        has_code('2017-03-12,wisdom', incorrect_msg=msg2)
+    )
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -169,11 +186,20 @@ history | tail -n 3 > steps.txt
 
 *** =sct3
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['history'],
-                      ['tail', 'n:', None, {'-n' : '3'}]],
-                     redirect='steps.txt',
-                     msg='Remember to redirect the output to `steps.txt`.')
+msg1="Make sure to redirect the output of your command to `steps.txt`."
+msg2="Have you used `history | tail ___ ___` (fill in the blanks) to populate `steps.txt`?"
+Ex().multi(
+    has_cwd('/home/repl'),
+    # When run by the validator, solution3 doesn't pass, so including a has_code for that
+    check_or(
+        check_file('/home/repl/steps.txt', missing_msg=msg1).multi(
+            has_code('\s+1\s+', incorrect_msg=msg2),
+            has_code('\s+3\s+history', incorrect_msg=msg2)
+        ),
+        has_code('history\s+|\s+tail\s+-n\s+4\s+>\s+steps\.txt')
+    )
+)
+Ex().success_msg("Well done! Let's step it up!")
 ```
 
 --- type:BulletConsoleExercise key:4507a0dbd8
@@ -213,7 +239,7 @@ which produces the same output as running the commands directly.
 *** =instructions1
 
 Use `nano dates.sh` to create a file called `dates.sh`
-that uses this command:
+that contains this command:
 
 ```{shell}
 cut -d , -f 1 seasonal/*.csv
@@ -231,14 +257,19 @@ Put the commands shown into the file without extra blank lines or spaces.
 
 *** =solution1
 ```{shell}
-# Run "nano dates.sh" instead of the following command: 
+# This solution uses `cp` instead of `nano`
+# because our automated tests can't edit files interactively.
 cp /solutions/dates.sh .
 ```
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_compare_file_to_file
-Ex() >> test_compare_file_to_file('dates.sh', '/solutions/dates.sh')
+msg = "Have you included the line `cut -d , -f 1 seasonal/*.csv` in the `dates.sh` file? Use `nano dates.sh` again to update your file. Use Ctrl-O to save and Ctrl-X to exit."
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/dates.sh').\
+        has_code('cut -d , -f 1 seasonal/*.csv', fixed=True, incorrect_msg=msg)
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -265,21 +296,21 @@ bash dates.sh
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['bash', '', 'dates.sh']],
-                     msg='Use `bash` and the name of the file to run.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_expr_output(incorrect_msg="Have you used `bash dates.sh` to execute the file?")
+)
 ```
 
 --- type:BulletConsoleExercise key:da13667750
 ## How can I re-use pipes?
 
-A file full of shell commands is called a **[shell script](http://datacamp.github.io/glossary/#shell-script)**,
-or sometimes just a "script" for short.
-Scripts don't have to have names ending in `.sh`,
+A file full of shell commands is called a ***shell script**,
+or sometimes just a "script" for short. Scripts don't have to have names ending in `.sh`,
 but this lesson will use that convention
 to help you keep track of which files are scripts.
 
-Scripts may contain pipes.
+Scripts can also contain pipes.
 For example,
 if `all-dates.sh` contains this line:
 
@@ -309,11 +340,10 @@ shutil.copyfile('/solutions/teeth-start.sh', 'teeth.sh')
 
 *** =instructions1
 
-Use Nano to edit the shell script `teeth.sh`
-and replace the two `____` placeholders
-with `seasonal/*.csv` and `-c`
-so that this script prints a count of the number of times each tooth name appears in
-the CSV files in the `seasonal` directory.
+A file `teeth.sh` in your home directory has been prepared for you, but contains some blanks.
+Use Nano to edit the file and replace the two `____` placeholders
+with `seasonal/*.csv` and `-c` so that this script prints a count of the
+number of times each tooth name appears in the CSV files in the `seasonal` directory.
 
 *** =hint1
 
@@ -325,14 +355,19 @@ Use `nano teeth.sh` to edit the file.
 
 *** =solution1
 ```{shell}
-# Run "nano teeth.sh" instead of the following command: 
+# This solution uses `cp` instead of `nano`
+# because our automated tests can't edit files interactively.
 cp /solutions/teeth.sh .
 ```
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_compare_file_to_file
-Ex() >> test_compare_file_to_file('teeth.sh', '/solutions/teeth.sh')
+msg="Have you a replaced the blanks properly so the command in `teeth.sh` reads `cut -d , -f 2 seasonal/*.csv | grep -v Tooth | sort | uniq -c`? Use `nano teeth.sh` again to make the required changes."
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/teeth.sh').\
+        has_code('cut\s+-d\s+,\s+-f\s+2\s+seasonal/\*\.csv\s+\|\s+grep\s+-v\s+Tooth\s+\|\s+sort\s+\|\s+uniq\s+-c', incorrect_msg=msg)
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -354,7 +389,7 @@ Remember that `> teeth.out` must come *after* the command that is producing outp
 
 *** =solution2
 ```{shell}
-# We need to use 'cp' below to satisfy our automated back end.
+# We need to use 'cp' below to satisfy our automated tests.
 # You should only use the last line that runs 'bash'.
 cp /solutions/teeth.sh .
 bash teeth.sh > teeth.out
@@ -362,12 +397,14 @@ bash teeth.sh > teeth.out
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_compare_file_to_file, test_cmdline
-Ex() >> test_cmdline([['bash', '', 'teeth.sh']],
-                     redirect='teeth.out',
-                     last_line=True,
-                     msg='Run the script with `bash` and use `>` to redirect its output.') \
-     >> test_compare_file_to_file('teeth.out', '/solutions/teeth.out')
+msg="Have you correctly redirected the result of `bash teeth.sh` to `teeth.out` with the `>`?"
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/teeth.out').multi(
+        has_code('31 canine', incorrect_msg=msg),
+        has_code('17 wisdom', incorrect_msg=msg)
+    )
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -394,9 +431,8 @@ cat teeth.out
 
 *** =sct3
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_cmdline([['cat', '', 'teeth.out']],
-                     msg='Run the indicated command.')
+Ex().has_expr_output(incorrect_msg="Run `cat teeth.out` to have a look at the resulting file!")
+Ex().success_msg("Nice! This all may feel contrived at first, but the nice thing is that you are automating parts of your workflow step by step. Something that comes in really handy as a data scientist!")
 ```
 
 --- type:BulletConsoleExercise key:c2623b9c14
@@ -458,14 +494,19 @@ Use `nano count-records.sh` to edit the filename.
 
 *** =solution1
 ```{shell}
-# Run "nano count-records.sh" instead of the following command: 
+# This solution uses `cp` instead of `nano`
+# because our automated tests can't edit files interactively.
 cp /solutions/count-records.sh .
 ```
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_compare_file_to_file
-Ex() >> test_compare_file_to_file('count-records.sh', '/solutions/count-records.sh')
+msg="Have you a replaced the blanks properly so the command in `count-records.sh` reads `tail -q -n +2 $@ | wc -l`? Use `nano count-records.sh` again to make the required changes."
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/count-records.sh').\
+        has_code('tail\s+-q\s+-n\s+\+2\s+\$@\s+|\s+wc\s+-l', incorrect_msg=msg)
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -493,11 +534,12 @@ bash count-records.sh seasonal/*.csv > num-records.out
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_compare_file_to_file, test_cmdline
-Ex() >> test_student_typed(r'\s*bash\s+count-records\.sh\s+.+>\s*num-records.out\s*',
-                           fixed=False,
-                           msg='Run the script with `bash` and some filenames and use `>` to redirect its output.') \
-     >> test_compare_file_to_file('num-records.out', '/solutions/num-records.out')
+msg="Have you correctly redirected the result of `bash count-records.sh seasonal/*.csv` to `num-records.out` with the `>`?"
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/num-records.out').has_code('92', incorrect_msg=msg)
+)
+Ex().success_msg("A job well done! Your shell power is ever-expanding!")
 ```
 
 --- type:PureMultipleChoiceExercise lang:bash xp:50 key:4092cb4cda
@@ -547,7 +589,7 @@ Which of the following commands should be put in `get-field.sh` to do that?
 
 Remember that command-line parameters are numbered left to right.
 
-*** =feedbacks
+*** =feedback
 - No: that will try to use the filename as the number of lines to select with `head`.
 - Correct!
 - No: that will try to use the column number as the line number and vice versa.
@@ -593,14 +635,19 @@ Use `wc -l $@` to count lines in all the files given on the command line.
 
 *** =solution1
 ```{shell}
-# Run "nano range.sh" to update the file instead of the following command: 
+# This solution uses `cp` instead of `nano`
+# because our automated tests can't edit files interactively.
 cp /solutions/range-1.sh range.sh
 ```
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_compare_file_to_file
-Ex() >> test_compare_file_to_file('range.sh', '/solutions/range-1.sh')
+msg="Have you a replaced the blanks properly so the command in `range.sh` reads `wc -l $@ | grep -v total`? Use `nano range.sh` again to make the required changes."
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/range.sh').\
+        has_code('wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total', incorrect_msg=msg)
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -625,14 +672,19 @@ and then `head -n 1` to select the shortest line.
 
 *** =solution2
 ```{shell}
-# Run "nano range.sh" to update the file instead of the following command: 
+# This solution uses `cp` instead of `nano`
+# because our automated tests can't edit files interactively.
 cp /solutions/range-2.sh range.sh
 ```
 
 *** =sct2
 ```{python}
-from shellwhat_ext import test_compare_file_to_file
-Ex() >> test_compare_file_to_file('range.sh', '/solutions/range-2.sh')
+msg="Have you added `sort -n` and `head -n 1` with pipes to the `range.sh` file? Use `nano range.sh` again to make the required changes."
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/range.sh').\
+        has_code('wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total\s+\|\s+sort\s+-n\s+|\s+head\s+-n\s+1', incorrect_msg=msg)
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -657,14 +709,22 @@ Copy the first line and modify the sorting order.
 
 *** =solution3
 ```{shell}
-# Run "nano range.sh" to update the file instead of the following command: 
+# This solution uses `cp` instead of `nano`
+# because our automated tests can't edit files interactively.
 cp /solutions/range-3.sh range.sh
 ```
 
 *** =sct3
 ```{python}
-from shellwhat_ext import test_compare_file_to_file
-Ex() >> test_compare_file_to_file('range.sh', '/solutions/range-3.sh')
+msg1="Keep the first line in the `range.sh` file: `wc -l $@ | grep -v total | sort -n | head -n 1`"
+msg2="Have you duplicated the first line in `range.sh` and made a small change? `sort -n -r` instead of `sort -n`!"
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/range.sh').multi(
+        has_code('wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total\s+\|\s+sort\s+-n\s+|\s+head\s+-n\s+1', incorrect_msg=msg1),
+        has_code('wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total\s+\|\s+sort\s+-n\s+-r\s+|\s+head\s+-n\s+1', incorrect_msg=msg2)
+    )
+)
 ```
 
 *** =type4: ConsoleExercise
@@ -696,10 +756,15 @@ bash range.sh seasonal/*.csv > range.out
 
 *** =sct4
 ```{python}
-from shellwhat_ext import test_cmdline
-Ex() >> test_student_typed(r'\s*bash\s+range\.sh\s+seasonal/\*\.csv\s*>\s*range.out\s*',
-                           fixed=False,
-                           msg='Run the script with `bash` and `seasonal/*.csv` and use `>` to redirect its output.')
+msg="Have you correctly redirected the result of `bash range.sh seasonal/*.csv` to `range.out` with the `>`?"
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/range.out').multi(
+        has_code('21 seasonal/autumn.csv', fixed=True, incorrect_msg=msg),
+        has_code('26 seasonal/winter.csv', fixed=True, incorrect_msg=msg)
+    )
+)
+Ex().success_msg("This is going well. Head over to the next exercise to learn about writing loops!")
 ```
 
 --- type:BulletConsoleExercise key:6be8ca6009
@@ -721,7 +786,7 @@ done
 (You don't have to indent the commands inside the loop,
 but doing so makes things clearer.)
 
-The first line of this script is a **[comment](http://datacamp.github.io/glossary/#comment)**
+The first line of this script is a **comment**
 to tell readers what the script does.
 Comments start with the `#` character and run to the end of the line.
 Your future self will thank you for adding brief explanations like the one shown here
@@ -754,15 +819,27 @@ Remember to use `$filename` to get the current value of the loop variable.
 
 *** =solution1
 ```{shell}
-# We have to use 'cp' because our automated back end cannot edit a file.
-# Please use Nano to edit date-range.sh instead.
+# This solution uses `cp` instead of `nano`
+# because our automated tests can't edit files interactively.
 cp /solutions/date-range.sh date-range.sh
 ```
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_compare_file_to_file
-Ex() >> test_compare_file_to_file('date-range.sh', '/solutions/date-range.sh')
+msgpatt="In `date-range.sh`, have you changed the %s line in the loop to be `%s`? Use `nano date-range.sh` to make changes."
+cmdpatt = 'cut -d , -f 1 $filename | grep -v Date | sort | %s -n 1'
+msg1=msgpatt%('first', cmdpatt%'head')
+msg2=msgpatt%('second', cmdpatt%'tail')
+patt='cut\s+-d\s+,\s+-f\s+1\s+\$filename\s+\|\s+grep\s+-v\s+Date\s+\|\s+sort\s+\|\s+%s\s+-n\s+1'
+patt1 = patt%'head'
+patt2 = patt%'tail'
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/date-range.sh').multi(
+        has_code(patt1, incorrect_msg=msg1),
+        has_code(patt2, incorrect_msg=msg2)
+    )
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -792,9 +869,10 @@ bash date-range.sh seasonal/*.csv
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'.*\s*bash\s+date-range\.sh\s+seasonal/\*(\.csv)?\s*',
-                           fixed=False,
-                           msg='Use `bash date-range.sh` on `seasonal/*.csv`.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_expr_output(incorrect_msg='Have you used `bash date-range.sh` on `seasonal/*.csv`?')
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -804,11 +882,8 @@ Ex() >> test_student_typed(r'.*\s*bash\s+date-range\.sh\s+seasonal/\*(\.csv)?\s*
 
 *** =instructions3
 
-
 Run `date-range.sh` on all four of the seasonal data files using `seasonal/*.csv` to match their names,
-
-and pipe its output to `sort`
-to see that your scripts can be used just like Unix's built-in commands.
+and pipe its output to `sort` to see that your scripts can be used just like Unix's built-in commands.
 
 *** =hint3
 
@@ -825,9 +900,11 @@ bash date-range.sh seasonal/*.csv | sort
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'.*\s*bash\s+date-range\.sh\s+seasonal/\*(\.csv)?\s*|\s*sort\s*',
-                           fixed=False,
-                           msg='Pipe `bash date-range.sh` with `seasonal/*.csv` to `sort`.')
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_expr_output(incorrect_msg='Starting from the command for the previous instruction, `bash date-range.sh seasonal/*.csv`, add a `|` to pipe its output to `sort`.')
+)
+Ex().success_msg("Magic! Notice how composable all the things we've learned are.")
 ```
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:8a162c4d54
@@ -879,6 +956,6 @@ What does `head` do if it doesn't have a filename and nothing is upstream from i
 ```{python}
 a1 = 'No, commands will not time out.'
 a2 = 'No, that will give `head` the text `somefile.txt` to process, but then it will hang up waiting for still more input.'
-a3 = 'Yes! You should use Ctrl-C to stop a running program.'
-Ex() >> test_mc(3, [a1, a2, a3])
+a3 = 'Yes! You should use Ctrl-C to stop a running program. This concludes this introductory course! If you're interested to learn more command line tools, we thoroughly recommend taking our intro to Git course!'
+Ex().has_chosen(3, [a1, a2, a3])
 ```

--- a/chapter5.md
+++ b/chapter5.md
@@ -635,6 +635,8 @@ you can create one that tells you how many records are in the shortest and longe
 i.e.,
 the range of your datasets' lengths.
 
+Note that in Nano, "copy and paste" is achieved by navigating to the line you want to copy, pressing `CTRL+K` to cut the line, then `CTRL+U` twice to paste two copies of it.
+
 *** =pre_exercise_code
 ```{python}
 import shutil
@@ -788,11 +790,19 @@ bash range.sh seasonal/*.csv > range.out
 ```{python}
 msg="Have you correctly redirected the result of `bash range.sh seasonal/*.csv` to `range.out` with the `>`?"
 Ex().multi(
-    has_cwd('/home/repl'),
+  has_cwd('/home/repl'),
+  check_correct(
     check_file('/home/repl/range.out').multi(
-        has_code('21 seasonal/autumn.csv', fixed=True, incorrect_msg=msg),
-        has_code('26 seasonal/winter.csv', fixed=True, incorrect_msg=msg)
+      has_code('21 seasonal/autumn.csv', fixed=True, incorrect_msg=msg),
+      has_code('26 seasonal/winter.csv', fixed=True, incorrect_msg=msg)
+    ),
+    multi(
+      has_code("bash", incorrect_msg = 'Did you call `bash`?'),
+      has_code("bash\s+range.sh", incorrect_msg = 'Did you run the `range.sh` file?'),
+      has_code("seasonal/*", incorrect_msg = 'Did you specify the files to process with `seasonal/*`?'),
+      has_code(">\s+range.out", incorrect_msg = 'Did you redirect to the `range.out` file?')
     )
+  )
 )
 Ex().success_msg("This is going well. Head over to the next exercise to learn about writing loops!")
 ```

--- a/chapter5.md
+++ b/chapter5.md
@@ -104,12 +104,12 @@ Use `cp` to copy and `~` as a shortcut for the path to your home directory.
 
 *** =solution1
 ```{shell}
-cp seasonal/s*.csv ~
+cp seasonal/s* ~
 ```
 
 *** =sct1
 ```{python}
-msg="Have you used `cp seasonal/s*.csv ~` to copy the required files to your home directory?"
+msg="Have you used `cp seasonal/s* ~` to copy the required files to your home directory?"
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/spring.csv', missing_msg=msg).\
@@ -117,6 +117,7 @@ Ex().multi(
     check_file('/home/repl/summer.csv', missing_msg=msg).\
         has_code(r'2017-01-11,canine', incorrect_msg=msg)
 )
+Ex().success_msg("Remarkable record-keeping! If you mistyped any commands, you can always use `nano` to clean up the saves history file afterwards.")
 ```
 
 *** =type2: ConsoleExercise

--- a/chapter5.md
+++ b/chapter5.md
@@ -564,7 +564,7 @@ Ex().multi(
     multi(
       has_code("bash", incorrect_msg = 'Did you call `bash`?'),
       has_code("bash\s+count-records.sh", incorrect_msg = 'Did you run the `count-records.sh` file?'),
-      has_code("seasonal/*", incorrect_msg = 'Did you specify the files to process with `seasonal/*`?'),
+      has_code("seasonal/\*", incorrect_msg = 'Did you specify the files to process with `seasonal/*`?'),
       has_code(">\s+num-records.out", incorrect_msg = 'Did you redirect to the `num-records.out` file?')
     )
   )
@@ -799,7 +799,7 @@ Ex().multi(
     multi(
       has_code("bash", incorrect_msg = 'Did you call `bash`?'),
       has_code("bash\s+range.sh", incorrect_msg = 'Did you run the `range.sh` file?'),
-      has_code("seasonal/*", incorrect_msg = 'Did you specify the files to process with `seasonal/*`?'),
+      has_code("seasonal/\*", incorrect_msg = 'Did you specify the files to process with `seasonal/*`?'),
       has_code(">\s+range.out", incorrect_msg = 'Did you redirect to the `range.out` file?')
     )
   )
@@ -910,8 +910,15 @@ bash date-range.sh seasonal/*.csv
 *** =sct2
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    has_expr_output(incorrect_msg='Have you used `bash date-range.sh` on `seasonal/*.csv`?')
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(),
+    multi(
+      has_code("bash", incorrect_msg = 'Did you call `bash`?'),
+      has_code("bash\s+date-range.sh", incorrect_msg = 'Did you run the `date-range.sh` file?'),
+      has_code("seasonal/\*", incorrect_msg = 'Did you specify the files to process with `seasonal/*`?')
+    )
+  )
 )
 ```
 
@@ -941,8 +948,17 @@ bash date-range.sh seasonal/*.csv | sort
 *** =sct3
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl'),
-    has_expr_output(incorrect_msg='Starting from the command for the previous instruction, `bash date-range.sh seasonal/*.csv`, add a `|` to pipe its output to `sort`.')
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(),
+    multi(
+      has_code("bash", incorrect_msg = 'Did you call `bash`?'),
+      has_code("bash\s+date-range.sh", incorrect_msg = 'Did you run the `date-range.sh` file?'),
+      has_code("seasonal/\*", incorrect_msg = 'Did you specify the files to process with `seasonal/*`?'),
+      has_code("|", incorrect_msg = 'Did you pipe from the script output to `sort`?'),
+      has_code("sort", incorrect_msg = 'Did you call `sort`?')
+    )
+  )
 )
 Ex().success_msg("Magic! Notice how composable all the things we've learned are.")
 ```

--- a/chapter5.md
+++ b/chapter5.md
@@ -300,7 +300,7 @@ bash dates.sh
 Ex().multi(
   has_cwd('/home/repl'),
   check_correct(
-    has_expr_output(incorrect_msg="Have you used `bash dates.sh` to execute the file?"),
+    has_expr_output(),
     multi(
       has_code("bash", incorrect_msg = 'Did you call `bash`?'),
       has_code("dates.sh", incorrect_msg = 'Did you specify the `dates.sh` file?')
@@ -406,11 +406,18 @@ bash teeth.sh > teeth.out
 ```{python}
 msg="Have you correctly redirected the result of `bash teeth.sh` to `teeth.out` with the `>`?"
 Ex().multi(
-    has_cwd('/home/repl'),
+  has_cwd('/home/repl'),
+  check_correct(
     check_file('/home/repl/teeth.out').multi(
-        has_code(r'31 canine', incorrect_msg=msg),
-        has_code(r'17 wisdom', incorrect_msg=msg)
+      has_code(r'31 canine', incorrect_msg=msg),
+      has_code(r'17 wisdom', incorrect_msg=msg)
+    ),
+    multi(
+      has_code("bash", incorrect_msg = 'Did you call `bash`?'),
+      has_code("bash\s+teeth.sh", incorrect_msg = 'Did you run the `teeth.sh` file?'),
+      has_code(">\s+teeth.sh", incorrect_msg = 'Did you redirect to the `teeth.out` file?')
     )
+  )
 )
 ```
 
@@ -438,7 +445,16 @@ cat teeth.out
 
 *** =sct3
 ```{python}
-Ex().has_expr_output(incorrect_msg="Run `cat teeth.out` to have a look at the resulting file!")
+Ex().multi(
+  has_cwd('/home/repl'),
+  check_correct(
+    has_expr_output(),
+    multi(
+      has_code("cat", incorrect_msg = 'Did you call `cat`?'),
+      has_code("teeth.out", incorrect_msg = 'Did you specify the `teeth.out` file?')
+    )
+  )
+)
 Ex().success_msg("Nice! This all may feel contrived at first, but the nice thing is that you are automating parts of your workflow step by step. Something that comes in really handy as a data scientist!")
 ```
 

--- a/chapter5.md
+++ b/chapter5.md
@@ -54,10 +54,10 @@ patt = "Have you included the line `%s` in the `names.txt` file? Use `nano names
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/names.txt').multi(
-        has_code('Lovelace', incorrect_msg=patt%'Lovelace'),
-        has_code('Hopper', incorrect_msg=patt%'Hopper'),
-        has_code('Johnson', incorrect_msg=patt%'Johnson'),
-        has_code('Wilson', incorrect_msg=patt%'Wilson')
+        has_code(r'Lovelace', incorrect_msg=patt%'Lovelace'),
+        has_code(r'Hopper', incorrect_msg=patt%'Hopper'),
+        has_code(r'Johnson', incorrect_msg=patt%'Johnson'),
+        has_code(r'Wilson', incorrect_msg=patt%'Wilson')
     )
 )
 Ex().success_msg("Well done! Off to the next one!")
@@ -113,9 +113,9 @@ msg="Have you used `cp seasonal/s*.csv ~` to copy the required files to your hom
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/spring.csv', missing_msg=msg).\
-        has_code('2017-01-25,wisdom', incorrect_msg=msg),
+        has_code(r'2017-01-25,wisdom', incorrect_msg=msg),
     check_file('/home/repl/summer.csv', missing_msg=msg).\
-        has_code('2017-01-11,canine', incorrect_msg=msg)
+        has_code(r'2017-01-11,canine', incorrect_msg=msg)
 )
 ```
 
@@ -151,9 +151,9 @@ msg2 = "Have you used `grep -h -v ___ ___ ___` (fill in the blanks) to populate 
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/temp.csv', missing_msg=msg1).multi(
-        has_code('2017-08-04,canine', incorrect_msg=msg2),
-        has_code('2017-03-14,incisor', incorrect_msg=msg2),
-        has_code('2017-03-12,wisdom', incorrect_msg=msg2)
+        has_code(r'2017-08-04,canine', incorrect_msg=msg2),
+        has_code(r'2017-03-14,incisor', incorrect_msg=msg2),
+        has_code(r'2017-03-12,wisdom', incorrect_msg=msg2)
     )
 )
 ```
@@ -193,10 +193,10 @@ Ex().multi(
     # When run by the validator, solution3 doesn't pass, so including a has_code for that
     check_or(
         check_file('/home/repl/steps.txt', missing_msg=msg1).multi(
-            has_code('\s+1\s+', incorrect_msg=msg2),
-            has_code('\s+3\s+history', incorrect_msg=msg2)
+            has_code(r'\s+1\s+', incorrect_msg=msg2),
+            has_code(r'\s+3\s+history', incorrect_msg=msg2)
         ),
-        has_code('history\s+|\s+tail\s+-n\s+4\s+>\s+steps\.txt')
+        has_code(r'history\s+|\s+tail\s+-n\s+4\s+>\s+steps\.txt')
     )
 )
 Ex().success_msg("Well done! Let's step it up!")
@@ -366,7 +366,7 @@ msg="Have you a replaced the blanks properly so the command in `teeth.sh` reads 
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/teeth.sh').\
-        has_code('cut\s+-d\s+,\s+-f\s+2\s+seasonal/\*\.csv\s+\|\s+grep\s+-v\s+Tooth\s+\|\s+sort\s+\|\s+uniq\s+-c', incorrect_msg=msg)
+        has_code(r'cut\s+-d\s+,\s+-f\s+2\s+seasonal/\*\.csv\s+\|\s+grep\s+-v\s+Tooth\s+\|\s+sort\s+\|\s+uniq\s+-c', incorrect_msg=msg)
 )
 ```
 
@@ -401,8 +401,8 @@ msg="Have you correctly redirected the result of `bash teeth.sh` to `teeth.out` 
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/teeth.out').multi(
-        has_code('31 canine', incorrect_msg=msg),
-        has_code('17 wisdom', incorrect_msg=msg)
+        has_code(r'31 canine', incorrect_msg=msg),
+        has_code(r'17 wisdom', incorrect_msg=msg)
     )
 )
 ```
@@ -505,7 +505,7 @@ msg="Have you a replaced the blanks properly so the command in `count-records.sh
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/count-records.sh').\
-        has_code('tail\s+-q\s+-n\s+\+2\s+\$@\s+|\s+wc\s+-l', incorrect_msg=msg)
+        has_code(r'tail\s+-q\s+-n\s+\+2\s+\$@\s+|\s+wc\s+-l', incorrect_msg=msg)
 )
 ```
 
@@ -537,7 +537,7 @@ bash count-records.sh seasonal/*.csv > num-records.out
 msg="Have you correctly redirected the result of `bash count-records.sh seasonal/*.csv` to `num-records.out` with the `>`?"
 Ex().multi(
     has_cwd('/home/repl'),
-    check_file('/home/repl/num-records.out').has_code('92', incorrect_msg=msg)
+    check_file('/home/repl/num-records.out').has_code(r'92', incorrect_msg=msg)
 )
 Ex().success_msg("A job well done! Your shell power is ever-expanding!")
 ```
@@ -646,7 +646,7 @@ msg="Have you a replaced the blanks properly so the command in `range.sh` reads 
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/range.sh').\
-        has_code('wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total', incorrect_msg=msg)
+        has_code(r'wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total', incorrect_msg=msg)
 )
 ```
 
@@ -683,7 +683,7 @@ msg="Have you added `sort -n` and `head -n 1` with pipes to the `range.sh` file?
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/range.sh').\
-        has_code('wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total\s+\|\s+sort\s+-n\s+|\s+head\s+-n\s+1', incorrect_msg=msg)
+        has_code(r'wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total\s+\|\s+sort\s+-n\s+|\s+head\s+-n\s+1', incorrect_msg=msg)
 )
 ```
 
@@ -721,8 +721,8 @@ msg2="Have you duplicated the first line in `range.sh` and made a small change? 
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/range.sh').multi(
-        has_code('wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total\s+\|\s+sort\s+-n\s+|\s+head\s+-n\s+1', incorrect_msg=msg1),
-        has_code('wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total\s+\|\s+sort\s+-n\s+-r\s+|\s+head\s+-n\s+1', incorrect_msg=msg2)
+        has_code(r'wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total\s+\|\s+sort\s+-n\s+|\s+head\s+-n\s+1', incorrect_msg=msg1),
+        has_code(r'wc\s+-l\s+\$@\s+\|\s+grep\s+-v\s+total\s+\|\s+sort\s+-n\s+-r\s+|\s+head\s+-n\s+1', incorrect_msg=msg2)
     )
 )
 ```

--- a/requirements.sh
+++ b/requirements.sh
@@ -5,9 +5,7 @@ USER_GROUP=repl:repl
 COURSE_ID=course_5065
 FILESYS=filesys.zip
 SOLUTIONS=solutions.zip
-PYTHON=python3
-PIP=pip3
-SHELLWHAT_EXT=git+https://github.com/datacamp/shellwhat_ext.git@v0.2.0
+SHELLWHAT_EXT=git+https://github.com/datacamp/shellwhat_ext.git@adding-condition-and-cwd
 
 # Report start.
 echo ''
@@ -18,6 +16,12 @@ echo 'USER_GROUP: ' ${USER_GROUP}
 echo 'COURSE_ID: ' ${COURSE_ID}
 echo 'FILESYS: ' ${FILESYS}
 echo
+
+## Install dev version of shellwhat and later version of protowhat
+## Rebuild 1-2-3-4
+pip3 install jinja2==2.10
+pip3 install protowhat==1.1.0
+pip3 install git+https://github.com/datacamp/shellwhat.git@fs/refactor --no-dependencies
 
 # Make sure we're in the home directory.
 cd ${HOME_DIR}
@@ -31,10 +35,6 @@ apt-get update
 apt-get -y install nano
 apt-get -y install unzip
 
-# Install the shellwhat_ext extensions.
-${PIP} install ${SHELLWHAT_EXT} --no-deps
-${PYTHON} -c "import sys; print('sys.version:', sys.version)"
-${PYTHON} -c "import shellwhat_ext; print('shellwhat_ext version:', shellwhat_ext.__version__)"
 
 # Unpack to the local directory.
 unzip ./${FILESYS}

--- a/requirements.sh
+++ b/requirements.sh
@@ -21,7 +21,7 @@ echo
 ## Rebuild 1-2-3-4
 pip3 install jinja2==2.10
 pip3 install protowhat==1.1.0
-pip3 install git+https://github.com/datacamp/shellwhat.git@fs/refactor --no-dependencies
+pip3 install shellwhat==1.0.0 --no-dependencies
 
 # Make sure we're in the home directory.
 cd ${HOME_DIR}

--- a/rules.yml
+++ b/rules.yml
@@ -1,0 +1,13 @@
+rules:
+    course_pct_ex_assignment_lte_reco:
+        min: 0
+        max: 1
+    course_pct_ex_code_sample_lte_reco:
+        min: 0
+        max: 1
+    course_pct_ex_code_solution_lte_reco:
+        min: 0
+        max: 1
+    mce_num_chars_assignment:
+        min: 0
+        max: 2000

--- a/unused/permissions.md
+++ b/unused/permissions.md
@@ -39,7 +39,7 @@ Use the same command shown in the lesson.
 ```{python}
 err = "No - you are looking at the wrong column."
 correct = "That's correct!"
-Ex() >> test_mc(3, [err, err, correct])
+Ex().has_chosen(3, [err, err, correct])
 ```
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:3061b5a818
@@ -91,7 +91,7 @@ a1 = 'Correct!'
 a2 = 'No: the third group of characters does not contain a "w".'
 a3 = 'No: the third group of characters does not contain an "x".'
 a4 = 'No: the third group of characters contains an "r".'
-Ex() >> test_mc(1, [a1, a2, a3, a4])
+Ex().has_chosen(1, [a1, a2, a3, a4])
 ```
 
 --- type:ConsoleExercise lang:shell xp:100 skills:1 key:f1988ccaf6
@@ -141,8 +141,7 @@ chmod u=r people/agarwal.txt
 
 *** =sct
 ```{shell}
-from shellwhat_ext import test_file_perms
-Ex() >> test_file_perms('people/agarwal.txt', 'r', 'is not readable.')
+# Ex() >> test_file_perms('people/agarwal.txt', 'r', 'is not readable.')
 ```
 
 --- type:BulletConsoleExercise key:6445630844
@@ -190,9 +189,7 @@ chmod u=rwx bin/lines.sh
 
 *** =sct1
 ```{python}
-from shellwhat_ext import test_file_perms
-Ex() >> test_file_perms('bin/lines.sh', 'x',
-                        'is not executable (did you forget `chmod`?).')
+#Ex() >> test_file_perms('bin/lines.sh', 'x', 'is not executable (did you forget `chmod`?).')
 ```
 
 *** =type2: ConsoleExercise
@@ -220,8 +217,7 @@ lines.sh seasonal/*.csv
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*lines\.sh\s+seasonal/\*\.csv\s*', \
-                           fixed=False, \
-                           msg='Type the name of the script and the wildcard pattern for the files.')
+Ex().has_code(r'\s*lines\.sh\s+seasonal/\*\.csv\s*',
+              fixed=False, incorrect_msg='Type the name of the script and the wildcard pattern for the files.')
 ```
 


### PR DESCRIPTION
Major refactor of SCTs  …

- Install development versions of protowhat and shellwhat
- Rewrite all chapters' SCTs
    - Look at side effects of commands whenever possible to allow for more flexibility.
    - No longer depend on any shellwhat_ext functions
- Clean up requirements.sh file slightly
- Clean up README and other file

Closes #148 
Closes #147 
Closes #114 
Closes #104
Closes #70
Closes #125 

As you can see, I haven't changed too much about assignment text, instructions and those kinds of things, even though I think the course could use some love. Overall, the presentation is pretty dry, and there is sometimes a lack of context about the state of the shell. I considered addressing this outside of the scope of my job here, which is fixing and improving SCTs.

Let me know if there are any questions.